### PR TITLE
Reduce Conda environment creation time (and thus RTD build time)

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,13 +1,11 @@
 name: docs.nextstrain.org
 channels:
   - defaults
-  - conda-forge
 dependencies:
   - make
   - recommonmark
   - sphinx
-  - sphinx-markdown-tables
-  - sphinx_rtd_theme
   - pip
   - pip:
     - nextstrain-sphinx-theme>=2020.2
+    - sphinx-markdown-tables


### PR DESCRIPTION
conda-forge is a huge package channel that we only needed for
sphinx-markdown-tables and the most recent sphinx_rtd_theme.  Install
the former via pip instead and remove the latter since it's transitively
dep'd through our own theme now.