### PR TITLE
Fetch remote documents more quickly

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,6 +4,7 @@ channels:
 dependencies:
   - make
   - recommonmark
+  - requests
   - sphinx
   - pip
   - pip:


### PR DESCRIPTION
Thread-based concurrency reduces time in I/O wait.  Connection pooling
eliminates the overhead of the initial TCP connection to the same host.
Making the request from within Python instead of shelling out to curl
avoids the overhead of spawning and managing a new process.

A quicker fetch is much nicer when iterating on docs locally and
frequently rebuilding.
