### PR TITLE
Add instructions to update conda prior to installation

### DIFF
--- a/src/guides/install/local-installation.md
+++ b/src/guides/install/local-installation.md
@@ -13,7 +13,15 @@ If you have any issues with installing Augur/Auspice using any of these methods,
 ---
 ## Install Augur & Auspice with Conda
 
-[Download and install the latest version of Miniconda](https://conda.io/miniconda.html) which will make the `conda` command available to you.
+[Download and install the latest version of Miniconda with Python 3](https://conda.io/miniconda.html) which will make the `conda` command available to you.
+If you already have Miniconda installed with Python 2, download the latest Python 3 version and [follow conda's installation instructions](https://conda.io/projects/conda/en/latest/user-guide/install/index.html).
+If you already have an older Miniconda version installed with Python 3, you may need to update your installation prior to installing Nextstrain's tools with:
+
+```sh
+conda activate base
+conda update conda
+```
+
 We're going to create a new environment called "nextstrain", which automatically installs `Augur` and dependencies.
 We'll then install `Auspice` into this environment as well, and optionally set up the `Nextstrain` command.
 

--- a/src/guides/install/local-installation.md
+++ b/src/guides/install/local-installation.md
@@ -5,7 +5,7 @@ The following instructions describe how to install `augur` (bioinformatics tooli
 
 > Before digging in, it's worth reading about [the different installation methods](./index) which will install the components behind Nextstrain and allow you to run and visualize analyses on your computer.
 
-If you would prefer to install each component individually, please see the respecive installation guides using the links in the sidebar. 
+If you would prefer to install each component individually, please see the respective installation guides using the links in the sidebar.
 If you are using Windows, we have instructions for [installing a Linux subsystem](./windows-help) to get Nextstrain running.
 If you have any issues with installing Augur/Auspice using any of these methods, please [email us](mailto:hello@nextstrain.org) or submit a GitHub issue to [Augur](https://github.com/nextstrain/augur/issues) or [Auspice](https://github.com/nextstrain/auspice/issues).
 


### PR DESCRIPTION
Based on [user feedback](https://github.com/openjournals/joss-reviews/issues/2906#issuecomment-748244561), this commit adds instructions for users who already have an older version of Miniconda installed and may need to update their installation before the Nextstrain installation will work.