### PR TITLE
Improve docs to update a local installation

### DIFF
--- a/src/guides/install/local-installation.md
+++ b/src/guides/install/local-installation.md
@@ -52,10 +52,21 @@ conda deactivate
 ```
 
 
-## Updating `augur`, `auspice`, and `nextstrain`:
+## Updating
+
+> The following commands presume you have installed the software via the method described above.
+
+Firstly, ensure that `conda` itself is up-to-date!
+```sh
+conda activate base
+conda update conda
+conda activate nextstrain
+```
+
+Then we can update each individual piece, as necessary:
 
 ```sh
-conda activate nextstrain
-pip install --upgrade nextstrain-augur nextstrain-cli
+python3 -m pip install --upgrade nextstrain-cli
+conda install --update-deps -c conda-forge -c bioconda augur # will also update mafft etc
 npm update --global auspice
 ```

--- a/src/guides/install/local-installation.md
+++ b/src/guides/install/local-installation.md
@@ -51,22 +51,32 @@ nextstrain -h
 conda deactivate
 ```
 
-
-## Updating
+## Update an existing installation
 
 > The following commands presume you have installed the software via the method described above.
 
-Firstly, ensure that `conda` itself is up-to-date!
+First, update the base `conda` environment.
+
 ```sh
 conda activate base
 conda update conda
-conda activate nextstrain
 ```
 
-Then we can update each individual piece, as necessary:
+Then, update each individual program, as necessary.
 
 ```sh
-python3 -m pip install --upgrade nextstrain-cli
-conda install --update-deps -c conda-forge -c bioconda augur # will also update mafft etc
+conda activate nextstrain
+
+# Update Nextstrain dependencies (mafft, etc.).
+conda update --all
+
+# Update Augur.
+python3 -m pip install --upgrade nextstrain-augur
+
+# Update Auspice.
 npm update --global auspice
+
+# Update the Nextstrain CLI and pull the latest Docker image.
+python3 -m pip install --upgrade nextstrain-cli
+nextstrain update
 ```


### PR DESCRIPTION
Previous instructions had a few shortcomings, including using `pip` rather than our preferred `python3 -m pip`, failed to update `conda` itself, and failed to update the external dependencies of `augur` which can't be installed by `pip` (`mafft` etc)