### PR TITLE
Update instructions to update Nextstrain with Bioconda

### DIFF
--- a/src/guides/install/local-installation.md
+++ b/src/guides/install/local-installation.md
@@ -72,7 +72,4 @@ conda update --all
 
 # Update Auspice.
 npm update --global auspice
-
-# Pull the latest Docker image for the CLI.
-nextstrain update
 ```

--- a/src/guides/install/local-installation.md
+++ b/src/guides/install/local-installation.md
@@ -67,16 +67,12 @@ Then, update each individual program, as necessary.
 ```sh
 conda activate nextstrain
 
-# Update Nextstrain dependencies (mafft, etc.).
+# Update Nextstrain dependencies (mafft, etc.), Augur, and Nextstrain CLI.
 conda update --all
-
-# Update Augur.
-python3 -m pip install --upgrade nextstrain-augur
 
 # Update Auspice.
 npm update --global auspice
 
-# Update the Nextstrain CLI and pull the latest Docker image.
-python3 -m pip install --upgrade nextstrain-cli
+# Pull the latest Docker image for the CLI.
 nextstrain update
 ```


### PR DESCRIPTION
Given that the Nextstrain conda environment will [soon install Augur and the Nextstrain CLI from Bioconda](https://github.com/nextstrain/conda/pull/11), we can simplify the instructions to update the Nextstrain environment by removing references to pip upgrades of Augur and the CLI.
