### PR TITLE
Document how to delete files from Groups

### DIFF
--- a/src/guides/share/nextstrain-groups.rst
+++ b/src/guides/share/nextstrain-groups.rst
@@ -55,7 +55,8 @@ Define your credentials in this file like so, replacing the “…” values wit
 
 Save this file and return to the command line.
 
-Confirm that you have access to your Nextstrain Groups AWS resources, by listing the contents of your group’s S3 bucket. Replace ``<group>`` below with your group name.
+Confirm that you have access to your Nextstrain Groups AWS resources, by listing the contents of your group’s S3 bucket with :doc:`the nextstrain remote list command <cli:commands/remote/list>`.
+Replace ``<group>`` below with your group name.
 
 .. code-block:: bash
 
@@ -93,7 +94,7 @@ After the front matter (in the lines following the last ``---`` characters), wri
 Use `Markdown syntax <https://www.markdownguide.org/basic-syntax/>`_ to format the contents of your group description with headers, lists, links, etc.
 This content will appear between the byline and the list of available datasets on the group's page.
 
-Upload your logo and description to your group’s S3 bucket.
+Upload your logo and description to your group’s S3 bucket with :doc:`the nextstrain remote upload command <cli:commands/remote/upload>`.
 
 .. code-block:: bash
 
@@ -129,7 +130,7 @@ Alternately, upload multiple build files at once with wildcard syntax.
 Remove files from your group
 ============================
 
-You can remove specific files from your group's S3 bucket using the ``nextstrain remote delete`` command.
+You can remove specific files from your group's S3 bucket using :doc:`the nextstrain remote delete command <cli:commands/remote/delete>`.
 For example, the following command removes your group logo and overview files.
 
 .. code-block:: bash

--- a/src/guides/share/nextstrain-groups.rst
+++ b/src/guides/share/nextstrain-groups.rst
@@ -59,7 +59,7 @@ Confirm that you have access to your Nextstrain Groups AWS resources, by listing
 
 .. code-block:: bash
 
-   nextstrain remote ls s3://nextstrain-<group>
+   nextstrain remote list s3://nextstrain-<group>
 
 This command should list all the files in your bucket. Your bucket will likely be empty by default.
 
@@ -125,6 +125,26 @@ Alternately, upload multiple build files at once with wildcard syntax.
 .. code-block:: bash
 
    nextstrain remote upload s3://nextstrain-<group>/ auspice/*.json
+
+Remove files from your group
+============================
+
+You can remove specific files from your group's S3 bucket using the ``nextstrain remote delete`` command.
+For example, the following command removes your group logo and overview files.
+
+.. code-block:: bash
+
+   nextstrain remote delete s3://nextstrain-<group>/group-logo.png
+   nextstrain remote delete s3://nextstrain-<group>/group-overview.md
+
+Alternately, you can remove multiple files with the same prefix.
+For example, the following command removes all files associated with a specific build's prefix.
+
+.. code-block:: bash
+
+   nextstrain remote delete \
+     --recursively \
+     s3://nextstrain-<group>/ncov_<your-build-name>
 
 Learn more about the Nextstrain command line interface
 ======================================================


### PR DESCRIPTION
## Description of proposed changes

Adds a section about how to remove files to the Nextstrain Groups documentation with examples for removing specific files or a group of files matching a pattern.

Separately, expands the previous reference of `nextstrain remote ls` to `nextstrain remote list` for consistency throughout this page.

## Testing

Docs were tested locally and [via RTD hook with this PR](https://nextstrain--60.org.readthedocs.build/en/60/guides/share/nextstrain-groups.html#remove-files-from-your-group).