### PR TITLE
Add docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,42 @@
+FROM continuumio/miniconda3:4.9.2
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG USER=user
+ARG GROUP=user
+ARG UID=1000
+ARG GID=1000
+
+ENV TERM="xterm-256color"
+ENV HOME="/home/user"
+
+RUN set -x \
+  && mkdir -p ${HOME}/data \
+  && addgroup --system --gid ${GID} ${GROUP} \
+  && useradd --system --create-home --home-dir ${HOME} \
+  --shell /bin/zsh \
+  --gid ${GROUP} \
+  --groups sudo \
+  --uid ${UID} \
+  ${USER} \
+  && touch ${HOME}.hushlogin
+
+RUN set -x \
+  && chown -R ${USER}:${GROUP} ${HOME}
+
+COPY environment.yml ${HOME}/src/
+
+WORKDIR ${HOME}/src
+
+RUN set -x \
+  && conda env create docs.nextstrain.org
+
+USER ${USER}
+
+RUN set -x \
+  && conda init bash \
+  && echo "conda activate docs.nextstrain.org" >> ${HOME}/.bashrc
+
+CMD bash -c "set -x \
+  && source ${HOME}/.bashrc \
+  && make html \
+  "

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN set -x \
   && mkdir -p ${HOME}/data \
   && addgroup --system --gid ${GID} ${GROUP} \
   && useradd --system --create-home --home-dir ${HOME} \
-  --shell /bin/zsh \
+  --shell /bin/bash \
   --gid ${GROUP} \
   --groups sudo \
   --uid ${UID} \

--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,22 @@ BUILDDIR      = build
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-.PHONY: help Makefile
+.PHONY: help help-docker Makefile
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.ONESHELL:
+docker-html:
+	set -euox
+	docker build -t nextstrain-docs-builder --network=host .
+	docker run -it --rm \
+	--name=nextstrain-docs-builder-$(shell date +%s) \
+	--init \
+	--user=$(shell id -u):$(shell id -g) \
+	--volume=$(shell pwd):/home/user/src \
+	--workdir=/home/user/src \
+	--env 'TERM=xterm-256colors' \
+	nextstrain-docs-builder

--- a/README.md
+++ b/README.md
@@ -43,6 +43,18 @@ Read The Docs is configured via `readthedocs.yml`; [more about Read The Docs con
 
 Sphinx is configured via `src/conf.py`; [more about Sphinx configuration](https://www.sphinx-doc.org/en/master/usage/configuration.html)
 
+
+## Building the docs with Docker
+
+Alternatively, you can perform the same steps inside a container.
+
+Once you have [Docker](https://docs.docker.com/get-docker/) installed, run:
+
+    make docker-html
+
+The HTML files appear in `build/html/` as usual, and can be viewed in a browser.
+
+
 ## Implementation
 
 ### Document Formats


### PR DESCRIPTION
### Description of proposed changes    

This adds a `Dockerfile` and a `Makefile` target to build the container image and to run it.

This container performs the same actions as the local workflow described in the readme and produces the same results (except for conda environment, which is kept inside the image).

This is purely for convenience and for crazy folks who prefer to sandbox rando software packages from the local machine.

### Related issue(s)  

None

### Testing

No code changes

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
