### PR TITLE
Link to nextclade web tutorial

### DIFF
--- a/src/index.rst
+++ b/src/index.rst
@@ -9,8 +9,13 @@ Welcome to Nextstrain's documentation!
 
 Nextstrain is an open-source project to harness the scientific and public health potential of pathogen genome data.
 We provide a continually-updated view of publicly available data with powerful analyses and visualizations showing pathogen evolution and epidemic spread.
-Our goal is to aid epidemiological understanding and improve outbreak response.
-If you have any questions, or simply want to say hi, please give us a shout at hello@nextstrain.org.
+Our goal is to aid epidemiological understanding and improve outbreak response and we currently maintain the following tools to help you to analyze and visualize your own data:
+ - `Augur <https://docs.nextstrain.org/projects/augur/en/stable/index.html>`_ (phylogenetic analysis)
+ - `Auspice <https://docs.nextstrain.org/projects/auspice/en/stable/index.html>`_ (visualization)
+ - `Nextstrain CLI <https://docs.nextstrain.org/projects/cli/en/stable/index.html>`_ (command line utility)
+ - `Nextclade <https://docs.nextstrain.org/projects/nextclade/en/latest/index.html>`_ (QC, clade assignment, mutation calling)
+
+If you have any questions, or simply want to say hi, please give us a shout at hello@nextstrain.org or post at `discussion.nextstrain.org <https://discussion.nextstrain.org>`_.
 
 .. toctree::
    :maxdepth: 2

--- a/src/reference/index.rst
+++ b/src/reference/index.rst
@@ -15,4 +15,5 @@ Reference guides and API documentation that give implementation and usage detail
    Augur: A bioinformatics toolkit for phylogenetic analysis <https://docs.nextstrain.org/projects/augur/en/stable/index.html>
    Auspice: An Open-source Interactive Tool for Visualising Phylogenomic Data <https://docs.nextstrain.org/projects/auspice/en/stable/>
    Nextstrain command-line interface (CLI) <https://docs.nextstrain.org/projects/cli/en/latest/>
-   Nextclade: analysis of viral genomes <https://docs.nextstrain.org/projects/nextclade>
+   Nextclade CLI: Analysis, QC, and clade assignment of viral genomes <https://docs.nextstrain.org/projects/nextclade/en/latest/user/nextclade-cli.html>
+   Nextalign CLI: reference alignments of viral genomes <https://docs.nextstrain.org/projects/nextclade/en/latest/user/nextalign-cli.html>

--- a/src/tutorials/index.rst
+++ b/src/tutorials/index.rst
@@ -15,3 +15,4 @@ Tutorials to help you get started with Nextstrain!
    tb_tutorial
    SARS-CoV-2/index
    narratives-how-to-write
+   Evaluate the quality of your consensus sequences with Nextclade<https://docs.nextstrain.org/projects/nextclade/en/latest/user/nextclade-web.html>

--- a/src/tutorials/index.rst
+++ b/src/tutorials/index.rst
@@ -15,4 +15,4 @@ Tutorials to help you get started with Nextstrain!
    tb_tutorial
    SARS-CoV-2/index
    narratives-how-to-write
-   Evaluate the quality of your consensus sequences with Nextclade<https://docs.nextstrain.org/projects/nextclade/en/latest/user/nextclade-web.html>
+   Analyze your genomes with Nextclade in the browser <https://docs.nextstrain.org/projects/nextclade/en/latest/user/nextclade-web.html>


### PR DESCRIPTION
As @huddlej put it on slack:
> In addition to listing Nextclade under reference guides, it would be excellent to start integrating Nextclade more into the main docs through tutorials and how-to guides. For some users, Nextclade may be the only part of Nextstrain they need to do their job. If they had a link to “Evaluate the quality of your consensus sequences with Nextclade” as one of the first how-to guides, they would be set without needing to know that Nextclade was initially developed as a separate tool

> [This page](https://docs.nextstrain.org/projects/nextclade/en/latest/user/nextclade-web.html), for example, could be linked with a slightly more explanatory title as one of the first links in the main Nextstrain docs tutorials section

This adds that link to better surface the Nextclade tool. The only other currently existing nextclade docs that I could see being "surfaced" on docs.nextstrain.org are:
- [Nextclade CLI](https://docs.nextstrain.org/projects/nextclade/en/latest/user/nextclade-cli.html)
- [Nextalign CLI](https://docs.nextstrain.org/projects/nextclade/en/latest/user/nextalign-cli.html)

But since I couldn't come up with a good place to put them or the words to use in linking to them, I left them out for now.

I linked directly to nextclade docs instead of fetching them based on the assumption that users clicking on the nextclade tutorial would be ok/happy with getting shifted over to nextclade subproject's docs.
