### PR TITLE
Lay of the land

### DIFF
--- a/src/conf.py
+++ b/src/conf.py
@@ -37,7 +37,8 @@ extensions = [
     'sphinx_markdown_tables',
     'sphinxarg.ext',
     'sphinx.ext.autodoc',
-    'sphinx_tabs.tabs'
+    'sphinx_tabs.tabs',
+    'sphinx.ext.graphviz',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -67,6 +68,8 @@ html_theme_options = {
     'titles_only': True,
 }
 
+graphviz_output_format = "svg"
+
 
 # -- Cross-project references ------------------------------------------------
 
@@ -74,5 +77,6 @@ intersphinx_mapping = {
     'augur': ('https://docs.nextstrain.org/projects/augur/en/stable', None),
     'auspice': ('https://docs.nextstrain.org/projects/auspice/en/stable', None),
     'cli': ('https://docs.nextstrain.org/projects/cli/en/stable/', None),
+    'nextclade': ('https://docs.nextstrain.org/projects/nextclade/en/stable/', None),
     'ncov': ('https://docs.nextstrain.org/projects/ncov/en/latest/', None)
 }

--- a/src/conf.py
+++ b/src/conf.py
@@ -73,7 +73,6 @@ html_theme_options = {
 intersphinx_mapping = {
     'augur': ('https://docs.nextstrain.org/projects/augur/en/stable', None),
     'auspice': ('https://docs.nextstrain.org/projects/auspice/en/stable', None),
-    # should be able to be change to stable after the next cli release (post https://github.com/nextstrain/cli/pull/102):
-    'cli': ('https://docs.nextstrain.org/projects/cli/en/latest/', None),
+    'cli': ('https://docs.nextstrain.org/projects/cli/en/stable/', None),
     'ncov': ('https://docs.nextstrain.org/projects/ncov/en/latest/', None)
 }

--- a/src/index.rst
+++ b/src/index.rst
@@ -13,12 +13,12 @@ understanding and improve outbreak response.
 
 .. note::
 
-    This documentation site aims to cover all parts of Nextstrain.  If you already
-    have your bearings, see the :ref:`toc` below to dive right in.  If you're
-    interested in how to interpret what you see on nextstrain.org, please start
+    This documentation site aims to cover all parts of Nextstrain.  If you
+    already have your bearings, see the :ref:`toc` below to dive right in.  If
+    you're interested in how to interpret what you see on nextstrain.org, start
     with :doc:`/learn/interpret/index`.  If you’re ready to go beyond using the
-    website (or just plain curious!), please continue reading for an overview of
-    how the different pieces of Nextstrain fit together.
+    website (or just plain curious!), continue reading for an overview of how
+    the different pieces of Nextstrain fit together.
 
 The core components of Nextstrain are :doc:`Augur <augur:index>` and
 :doc:`Auspice <auspice:index>`.
@@ -211,10 +211,10 @@ well as integrated into builds.
 With this overview, you'll be better prepared to dive into the rest of the
 documentation listed in the :ref:`toc` below.
 
-If you have questions, need help, or simply want to say hi, please post to our
+If you have questions, need help, or simply want to say hi, post to our
 `discussion forum <https://discussion.nextstrain.org>`__ where the Nextstrain
 team and other Nextstrain users provide assistance.  For private inquiries,
-please `email the Nextstrain team <hello@nextstrain.org>`__.
+`email the Nextstrain team <hello@nextstrain.org>`__.
 
 .. toctree::
    :maxdepth: 2

--- a/src/index.rst
+++ b/src/index.rst
@@ -1,28 +1,228 @@
-.. Nextstrain documentation master file, created by
-   sphinx-quickstart on Wed May 27 21:13:56 2020.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
-
 ======================================
 Welcome to Nextstrain's documentation!
 ======================================
 
-Nextstrain is an open-source project to harness the scientific and public health potential of pathogen genome data.
-We provide a continually-updated view of publicly available data with powerful analyses and visualizations showing pathogen evolution and epidemic spread.
-Our goal is to aid epidemiological understanding and improve outbreak response and we currently maintain the following tools to help you to analyze and visualize your own data:
- - `Augur <https://docs.nextstrain.org/projects/augur/en/stable/index.html>`_ (phylogenetic analysis)
- - `Auspice <https://docs.nextstrain.org/projects/auspice/en/stable/index.html>`_ (visualization)
- - `Nextstrain CLI <https://docs.nextstrain.org/projects/cli/en/stable/index.html>`_ (command line utility)
- - `Nextclade <https://docs.nextstrain.org/projects/nextclade/en/latest/index.html>`_ (QC, clade assignment, mutation calling)
+Nextstrain is a project to harness the scientific and public health potential
+of pathogen genome data.  It's made up of many different pieces that all work
+together.  Through our website, `nextstrain.org <https://nextstrain.org>`__, we
+provide a continually-updated view of publicly available data with powerful
+analyses and visualizations showing pathogen evolution and epidemic spread.
+Through our open-source software tools, we aim to help you analyze and
+visualize your own data in the same way.  Our goal is to aid epidemiological
+understanding and improve outbreak response.
 
-If you have any questions, or simply want to say hi, please give us a shout at hello@nextstrain.org or post at `discussion.nextstrain.org <https://discussion.nextstrain.org>`_.
+.. note::
+
+    This documentation site aims to cover all parts of Nextstrain.  If you already
+    have your bearings, see the :ref:`toc` below to dive right in.  If you're
+    interested in how to interpret what you see on nextstrain.org, please start
+    with :doc:`/learn/interpret/index`.  If you’re ready to go beyond using the
+    website (or just plain curious!), please continue reading for an overview of
+    how the different pieces of Nextstrain fit together.
+
+The core components of Nextstrain are :doc:`Augur <augur:index>` and
+:doc:`Auspice <auspice:index>`.
+
+.. graphviz::
+    :align: center
+
+    digraph {
+        graph [
+            rankdir=LR,
+        ];
+
+        node [
+            shape=box,
+            style="rounded, filled",
+            fontname="Lato, 'Helvetica Neue', sans-serif",
+            fontsize=12,
+            height=0.1,
+            colorscheme=paired10,
+        ];
+
+        edge [
+            arrowhead=open,
+            arrowsize=0.75,
+        ];
+
+        Augur [fillcolor=1, color=2];
+        Auspice [fillcolor=3, color=4];
+
+        Augur -> Auspice;
+    }
+
+**Augur** is a series of composable, modular bioinformatics tools. We use these
+to create recipes for different pathogens and different analyses, which can be
+reproduced given the same input data and replicated when new data is available.
+
+.. graphviz::
+    :align: center
+
+    graph {
+        graph [
+            ranksep=0.25,
+        ];
+
+        node [
+            shape=box,
+            style="rounded, filled",
+            fontname="Lato, 'Helvetica Neue', sans-serif",
+            fontsize=12,
+            height=0.1,
+            colorscheme=paired10,
+            fillcolor=1,
+            color=2,
+        ];
+
+        edge [
+            arrowhead=open,
+            arrowsize=0.75,
+        ];
+
+        Augur -- ellipsis1 [style=invis];
+        ellipsis1 [label="…", shape=plain, style=""];
+
+        Augur -- {filter, align, tree, refine, export};
+
+        Augur -- ellipsis2 [style=invis];
+        ellipsis2 [label="…", shape=plain, style=""];
+    }
+
+**Auspice** is a web-based visualization program, to present and interact with
+phylogenomic and phylogeographic data. Auspice is what you see when, for
+example, you visit `nextstrain.org/mumps/na
+<https://nextstrain.org/mumps/na>`__.
+
+.. figure:: images/mumps.png
+
+    Auspice displaying Mumps genomes from North America.
+
+Augur produces :doc:`data files </reference/formats/data-formats>` which are
+visualized by Auspice.  These files are often referred to as "JSONs"
+colloquially because they use a generic data format called JSON.
+
+.. graphviz::
+    :align: center
+
+    digraph {
+        graph [
+            rankdir=LR,
+        ];
+
+        node [
+            shape=box,
+            style="rounded, filled",
+            fontname="Lato, 'Helvetica Neue', sans-serif",
+            fontsize=12,
+            height=0.1,
+            colorscheme=paired10,
+        ];
+
+        edge [
+            arrowhead=open,
+            arrowsize=0.75,
+        ];
+
+        Augur [fillcolor=1, color=2];
+        Auspice [fillcolor=3, color=4];
+        jsons [label="mumps_na.json\lmumps_na_root-sequence.json"];
+
+        Augur -> jsons -> Auspice;
+    }
+ 
+**Builds** are recipes of code and data that produce result **datasets** for
+visualization and analysis.  Builds run dozens of commands and often use
+`Snakemake <https://snakemake.readthedocs.io>`__ to :doc:`manage the pipeline
+workflow </guides/bioinformatics/augur_snakemake>`, but any workflow system can
+be used, such as `Nextflow <https://nextflow.io>`__ or `WDL
+<https://openwdl.org>`__.  As an example, our core builds are organized as `Git
+repositories <https://git-scm.com>`__ hosted on `GitHub
+<https://github.com/nextstrain>`__ which contain a Snakemake workflow using
+Augur, configuration, and data.
+
+.. graphviz::
+    :align: center
+
+    digraph {
+        graph [
+            ranksep=0.25,
+        ];
+
+        node [
+            shape=box,
+            style="rounded, filled",
+            fontname="Lato, 'Helvetica Neue', sans-serif",
+            fontsize=12,
+            height=0.1,
+            colorscheme=paired10,
+        ];
+
+        edge [
+            arrowhead=open,
+            arrowsize=0.75,
+        ];
+
+        subgraph Augur {
+            graph [rank=same];
+            node [fillcolor=1, color=2];
+            filter -> align -> tree -> refine -> export;
+        }
+
+        Auspice [fillcolor=3, color=4];
+
+        export -> Auspice;
+
+        subgraph inputs {
+            graph [rank=same];
+            sequences [label="sequences.fasta"];
+            metadata [label="metadata.tsv"];
+        }
+
+        sequences -> filter;
+        metadata -> filter;
+    }
+
+`nextstrain.org <https://nextstrain.org>`__ is a web application to host and
+present the core pathogen builds maintained by the Nextstrain team, as well as
+builds published to :doc:`Nextstrain Groups </guides/share/nextstrain-groups>`
+and :doc:`community pages </guides/share/community-builds>` which are
+maintained and :doc:`shared </guides/share/index>` by many other people.  The
+website incorporates a customized version of Auspice for displaying each
+dataset.
+
+You can run :doc:`Augur <augur:index>` and :doc:`Auspice <auspice:index>` on
+your own computer and use them independently or together with your own builds,
+our core builds, or other's group or community builds.  You can even install
+Auspice on :doc:`your own web server <auspice:server/index>` if you don't want
+to host your builds via nextstrain.org.
+
+The :doc:`Nextstrain CLI <cli:index>` (a program called ``nextstrain``) ties
+together all of the above to provide a consistent way to run pathogen builds,
+access Nextstrain components like Augur and Auspice across computing
+environments such as Docker, Conda, and AWS Batch, and publish datasets to
+nextstrain.org.
+
+:doc:`Nextclade <nextclade:index>` is a web application and two command-line
+programs (``nextclade`` and ``nextalign``) for performing viral genome
+alignment, mutation calling, clade assignment, quality checks, and phylogenetic
+placement.  Nextclade can be used indepedently of other Nextstrain tools as
+well as integrated into builds.
+
+With this overview, you'll be better prepared to dive into the rest of the
+documentation listed in the :ref:`toc` below.
+
+If you have questions, need help, or simply want to say hi, please post to our
+`discussion forum <https://discussion.nextstrain.org>`__ where the Nextstrain
+team and other Nextstrain users provide assistance.  For private inquiries,
+please `email the Nextstrain team <hello@nextstrain.org>`__.
 
 .. toctree::
    :maxdepth: 2
    :titlesonly:
-   :caption: Table of contents
+   :caption: Table of Contents
+   :name: toc
 
-   Nextstrain Documentation <self>
+   Introduction <self>
    install-nextstrain
    learn/index
    tutorials/index

--- a/src/index.rst
+++ b/src/index.rst
@@ -97,7 +97,7 @@ example, you visit `nextstrain.org/mumps/na
 
     Auspice displaying Mumps genomes from North America.
 
-Augur produces :doc:`data files </reference/formats/data-formats>` which are
+Augur produces :doc:`dataset files </reference/formats/data-formats>` which are
 visualized by Auspice.  These files are often referred to as "JSONs"
 colloquially because they use a generic data format called JSON.
 


### PR DESCRIPTION
Full rewrite, starting from some (less extensive) notes I wrote up
earlier this year describing the different pieces of Nextstrain to
someone.

The intent is to help people construct a mental model of the Nextstrain
ecosystem so they'll find it easier to navigate the docs and know what
they're looking for.  Each paragraph tries to build upon the previous
one to link together terminology, with hyperlinks to the topics
mentioned for immediate jumping off points and further reading.