### PR TITLE
Consistently link to the "stable" version of subproject docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ When editing those files in their respective repositories, keep in mind that any
 ### How to add a document
 1. What [type of document](#types-of-documents) is it? This will help write it with a clear goal in mind.
 2. Where should it go in the table of contents? See the Table of Contents at https://docs.nextstrain.org/en/latest/ to find a heading that fits the document best.
-3. Once the document is written, move it to the [directory](https://github.com/nextstrain/docs.nextstrain.org/tree/latest/src) corresponding to the heading under which you'd like to to appear, e.g.:
+3. Once the document is written, move it to the [directory](https://github.com/nextstrain/docs.nextstrain.org/tree/master/src) corresponding to the heading under which you'd like to to appear, e.g.:
 ```
 mv interacting-with-nextstrain.md src/learn/interpret/
 ```

--- a/src/reference/index.rst
+++ b/src/reference/index.rst
@@ -14,6 +14,6 @@ Reference guides and API documentation that give implementation and usage detail
    formats/index
    Augur: A bioinformatics toolkit for phylogenetic analysis <https://docs.nextstrain.org/projects/augur/en/stable/index.html>
    Auspice: An Open-source Interactive Tool for Visualising Phylogenomic Data <https://docs.nextstrain.org/projects/auspice/en/stable/>
-   Nextstrain command-line interface (CLI) <https://docs.nextstrain.org/projects/cli/en/latest/>
-   Nextclade CLI: Analysis, QC, and clade assignment of viral genomes <https://docs.nextstrain.org/projects/nextclade/en/latest/user/nextclade-cli.html>
-   Nextalign CLI: reference alignments of viral genomes <https://docs.nextstrain.org/projects/nextclade/en/latest/user/nextalign-cli.html>
+   Nextstrain command-line interface (CLI) <https://docs.nextstrain.org/projects/cli/en/stable/>
+   Nextclade CLI: Analysis, QC, and clade assignment of viral genomes <https://docs.nextstrain.org/projects/nextclade/en/stable/user/nextclade-cli.html>
+   Nextalign CLI: reference alignments of viral genomes <https://docs.nextstrain.org/projects/nextclade/en/stable/user/nextalign-cli.html>

--- a/src/tutorials/index.rst
+++ b/src/tutorials/index.rst
@@ -15,4 +15,4 @@ Tutorials to help you get started with Nextstrain!
    tb_tutorial
    Explore SARS-CoV-2 evolution <https://docs.nextstrain.org/projects/ncov/en/latest/index.html>
    narratives-how-to-write
-   Analyze your genomes with Nextclade in the browser <https://docs.nextstrain.org/projects/nextclade/en/latest/user/nextclade-web.html>
+   Analyze your genomes with Nextclade in the browser <https://docs.nextstrain.org/projects/nextclade/en/stable/user/nextclade-web.html>


### PR DESCRIPTION
When available.  The ncov subproject currently only has a "latest"
version.  Stable is a friendlier version to link to as it avoids issues
with documentation being ahead of released code.
    
If toctree supported Intersphinx links, then we wouldn't have these URLs
scattered around; they'd all be in src/conf.py.
