### PR TITLE
Run fetch-docs.py under the same Python that Sphinx is running under

### DIFF
--- a/src/conf.py
+++ b/src/conf.py
@@ -17,7 +17,7 @@ sys.path.insert(0, os.path.abspath('.'))
 # -- Fetch docs --------------------------------------------------------------
 
 import subprocess
-subprocess.check_call(['./fetch-docs.py'])
+subprocess.check_call([sys.executable or "python", './fetch-docs.py'])
 
 # -- Project information -----------------------------------------------------
 


### PR DESCRIPTION
Otherwise, fetch-docs.py may run under a completely different Python
version/environment/install than Sphinx because fetch-docs.py uses
whatever `python` is (via `#!/usr/bin/env python`) while Sphinx may be
invoked explicitly with a non-default Python.  @victorlin observed the
result of that failure mode in the VSCode integration with Sphinx.

