### PR TITLE
Update installation instructions for macOS/Windows/WSL

### DIFF
--- a/src/install.rst
+++ b/src/install.rst
@@ -126,6 +126,12 @@ These instructions will install the Nextstrain CLI and tools to run and view you
             conda activate nextstrain
 
       6. Install the remaining Nextstrain components by `installing Docker Desktop with WSL 2 backend <https://docs.docker.com/desktop/windows/wsl/>`_.
+
+         .. note::
+
+            You may have to restart your machine when configuring WSL (Windows Subsystem for Linux).
+            If so, remember to open a new Anaconda PowerShell Prompt and run ``conda activate nextstrain`` before the next step.
+
       7. Confirm that the installation worked.
 
          .. code-block:: none

--- a/src/install.rst
+++ b/src/install.rst
@@ -25,7 +25,7 @@ Background
 ==========
 
 `Conda <https://docs.conda.io/en/latest/>`_ is a package and environment management system that allows you to install Python and other software into controlled environments without disrupting other software you have installed (e.g., on your computer, your shared cluster, etc.).
-Conda provides an appropriate version of Python required by all approaches to installing Nextstrain tools.
+Conda provides an appropriate version of Python required by all approaches to installing Nextstrain tools. Miniconda is the minimal installation of the command-line interface to conda.
 
 `Mamba <https://github.com/mamba-org/mamba>`_ is a drop-in replacement for most ``conda`` functionality that implements a faster dependency solving algorithm in C++ and multithreaded downloads.
 As a result, mamba can install conda packages much faster and more accurately than the original conda installer.
@@ -46,7 +46,7 @@ These instructions will install the Nextstrain CLI and tools to run and view you
 
          If you are an experienced user, you can replace ``conda`` with ``pip`` but :doc:`note the extra installation steps for augur <augur:installation/installation>` and :doc:`install auspice via npm <auspice:introduction/install>`.
 
-      1. `Install Miniconda <https://docs.conda.io/projects/conda/en/latest/user-guide/install/download.html>`_.
+      1. `Install Miniconda <https://docs.conda.io/en/latest/miniconda.html>`_.
       2. Open a terminal window.
       3. Install mamba on the ``base`` conda environment:
 
@@ -89,7 +89,7 @@ These instructions will install the Nextstrain CLI and tools to run and view you
 
          Due to installation constraints, there is no way to use the native build/view environment on Windows directly. Follow steps for **WSL on Windows** if the native environment is desired.
 
-      1. `Install Miniconda <https://docs.conda.io/projects/conda/en/latest/user-guide/install/download.html>`_.
+      1. `Install Miniconda <https://docs.conda.io/en/latest/miniconda.html>`_.
       2. Install Visual C++ build tools following `this guide <https://stackoverflow.com/a/64262038>`_.
 
          - This is necessary for a dependency of Nextstrain CLI and `we are investigating options to eliminate this step <https://github.com/nextstrain/cli/issues/31#issuecomment-970641263>`_.

--- a/src/install.rst
+++ b/src/install.rst
@@ -60,7 +60,7 @@ These instructions will install the Nextstrain CLI and tools to run and view you
 
             .. code-block:: bash
 
-                  conda install -c conda-forge -c bioconda augur auspice snakemake --yes
+               conda install -c conda-forge -c bioconda augur auspice snakemake --yes
 
       5. Confirm that the installation worked.
 
@@ -141,7 +141,7 @@ These instructions will install the Nextstrain CLI and tools to run and view you
 
             .. code-block:: bash
 
-                  conda install -c conda-forge -c bioconda augur auspice snakemake --yes
+               conda install -c conda-forge -c bioconda augur auspice snakemake --yes
 
       6. Confirm that the installation worked.
 

--- a/src/install.rst
+++ b/src/install.rst
@@ -33,14 +33,7 @@ When you use the Docker build/view environment, you don’t need to manage any o
 Installation Steps
 ==================
 
-There are two components to install and configure. These are all the possible configuration options, with availability varying by operating system:
-
-1. Nextstrain CLI
-2. Nextstrain build/view environment:
-
-   a. Docker (build + view)
-   b. Native (build + view)
-   c. AWS Batch (build) + Docker/Native (view)
+These instructions will install the Nextstrain CLI and tools to run and view your own Nextstrain analyses. Configuration options vary by operating system.
 
 .. tabs::
 
@@ -60,7 +53,7 @@ There are two components to install and configure. These are all the possible co
             conda create -n nextstrain -c bioconda nextstrain-cli --yes
             conda activate nextstrain
 
-      4. Install the Nextstrain build/view environment. There are two options:
+      4. Install the remaining Nextstrain components. There are two options:
 
          a. Docker (recommended) – install Docker Desktop using `the official guide <https://docs.docker.com/desktop/mac/install/>`_.
          b. Native – install all the necessary software using conda:
@@ -75,7 +68,7 @@ There are two components to install and configure. These are all the possible co
 
             nextstrain check-setup --set-default
 
-         The final output from the last command should look like this, where ``<option>`` is the environment chosen in the previous step:
+         The final output from the last command should look like this, where ``<option>`` is the option chosen in the previous step:
 
          .. code-block:: none
 
@@ -101,7 +94,7 @@ There are two components to install and configure. These are all the possible co
             conda create -n nextstrain -c bioconda nextstrain-cli --yes
             conda activate nextstrain
 
-      5. Install the Nextstrain build/view environment by `installing Docker Desktop with WSL 2 backend <https://docs.docker.com/desktop/windows/wsl/>`_.
+      5. Install the remaining Nextstrain components by `installing Docker Desktop with WSL 2 backend <https://docs.docker.com/desktop/windows/wsl/>`_.
       6. Confirm that the installation worked.
 
          .. code-block:: none
@@ -138,7 +131,7 @@ There are two components to install and configure. These are all the possible co
             conda create -n nextstrain -c bioconda nextstrain-cli --yes
             conda activate nextstrain
 
-      5. Install the Nextstrain build/view environment. There are two options:
+      5. Install the remaining Nextstrain components. There are two options:
 
          a. Docker (recommended) – on Windows, `install Docker Desktop for WSL 2 backend <https://docs.docker.com/desktop/windows/wsl/>`_.
 
@@ -156,13 +149,13 @@ There are two components to install and configure. These are all the possible co
 
             nextstrain check-setup --set-default
 
-         The final output from the last command should look like this, where ``<option>`` is the environment chosen in the previous step:
+         The final output from the last command should look like this, where ``<option>`` is the option chosen in the previous step:
 
          .. code-block:: none
 
             Setting default environment to <option>.
 
-Optionally, :doc:`configure the AWS Batch build environment <cli:aws-batch>` to run the build step on AWS.
+Optionally, :doc:`configure AWS Batch <cli:aws-batch>` if you'd like to run ``nextstrain build`` on AWS.
 
 Next, try :doc:`tutorials/quickstart`.
 

--- a/src/install.rst
+++ b/src/install.rst
@@ -74,7 +74,7 @@ These instructions will install the Nextstrain CLI and tools to run and view you
 
             .. code-block:: bash
 
-               mamba install -c conda-forge -c bioconda augur auspice snakemake --yes
+               mamba install -c conda-forge -c bioconda augur auspice nextalign snakemake git --yes
 
       6. Confirm that the installation worked.
 
@@ -185,7 +185,7 @@ These instructions will install the Nextstrain CLI and tools to run and view you
 
             .. code-block:: bash
 
-               mamba install -c conda-forge -c bioconda augur auspice snakemake --yes
+               mamba install -c conda-forge -c bioconda augur auspice nextalign snakemake git --yes
 
       7. Confirm that the installation worked.
 
@@ -257,7 +257,7 @@ These instructions will install the Nextstrain CLI and tools to run and view you
 
             .. code-block:: bash
 
-                  mamba install -c conda-forge -c bioconda augur auspice snakemake --yes
+                  mamba install -c conda-forge -c bioconda augur auspice nextalign snakemake git --yes
 
       5. Confirm that the installation worked.
 

--- a/src/install.rst
+++ b/src/install.rst
@@ -6,7 +6,7 @@ Installing Nextstrain
 
     Before installing, we recommend you read about the :doc:`parts of Nextstrain </learn/parts>`.
 
-The following instructions describe how to install Nextstrain's software tools with Conda or Docker, including:
+The following instructions describe how to install Nextstrain's software tools, including:
 
   * Augur: a bioinformatics toolkit for the analysis of pathogen genomes
   * Auspice: a tool for interactive visualization of pathogen evolution
@@ -14,140 +14,176 @@ The following instructions describe how to install Nextstrain's software tools w
 
 .. note::
 
-    If you want to :doc:`contribute to the development of Nextstrain </guides/contribute/index>` or if you prefer to manage your own custom environment (e.g., a Conda environment, Docker image, environment modules on a cluster, etc.), see the individual installation documentation for :doc:`Nextstrain CLI <cli:installation>`, :doc:`Augur <augur:installation/installation>`, or :doc:`Auspice <auspice:introduction/install>`.
+    If you want to :doc:`contribute to the development of Nextstrain </guides/contribute/index>` or if you prefer to manage your own custom environment (e.g., a Conda environment, Docker image, environment modules on a cluster, etc.), see the individual installation documentation for :doc:`Nextstrain CLI <cli:installation>`, :doc:`Augur <augur:installation/installation>`, and :doc:`Auspice <auspice:introduction/install>`.
 
 .. contents:: Table of Contents
    :local:
    :depth: 1
 
-Install Conda
-=============
+
+Background
+==========
 
 `Conda <https://docs.conda.io/en/latest/>`_ is a package and environment management system that allows you to install Python and other software into controlled environments without disrupting other software you have installed (e.g., on your computer, your shared cluster, etc.).
 Conda provides an appropriate version of Python required by all approaches to installing Nextstrain tools.
 
+`Docker <https://docker.com/>`_ is a container system freely-available for all platforms.
+When you use the Docker build/view environment, you don’t need to manage any other Nextstrain software dependencies as validated versions are already bundled into `a container image by the Nextstrain team <https://github.com/nextstrain/docker-base/>`_.
+
+Installation Steps
+==================
+
+There are two components to install and configure. These are all the possible configuration options, with availability varying by operating system:
+
+1. Nextstrain CLI
+2. Nextstrain build/view environment:
+
+   a. Docker (build + view)
+   b. Native (build + view)
+   c. AWS Batch (build) + Docker/Native (view)
+
+.. tabs::
+
+   .. group-tab:: macOS
+
+      .. note::
+
+         If you are an experienced user, you can replace ``conda`` with ``pip`` but :doc:`note the extra installation steps for augur <augur:installation/installation>` and :doc:`install auspice via npm <auspice:introduction/install>`.
+
+      1. Install `Anaconda or Miniconda <https://docs.conda.io/projects/conda/en/latest/user-guide/install/download.html>`_.
+         Miniconda is sufficient for this guide.
+      2. Open a terminal window.
+      3. Create a conda environment named ``nextstrain`` and install the Nextstrain CLI:
+
+         .. code-block:: bash
+
+            conda create -n nextstrain -c bioconda nextstrain-cli --yes
+            conda activate nextstrain
+
+      4. Install the Nextstrain build/view environment. There are two options:
+
+         a. Docker (recommended) – install Docker Desktop using `the official guide <https://docs.docker.com/desktop/mac/install/>`_.
+         b. Native – install all the necessary software using conda:
+
+            .. code-block:: bash
+
+                  conda install -c conda-forge -c bioconda augur auspice snakemake --yes
+
+      5. Confirm that the installation worked.
+
+         .. code-block:: bash
+
+            nextstrain check-setup --set-default
+
+         The final output from the last command should look like this, where ``<option>`` is the environment chosen in the previous step:
+
+         .. code-block:: none
+
+            Setting default environment to <option>.
+
+   .. group-tab:: Windows
+
+      .. note::
+
+         Due to installation constraints, there is no way to use the native build/view environment on Windows directly. Follow steps for **WSL on Windows** if the native environment is desired.
+
+      1. Install `Anaconda or Miniconda <https://docs.conda.io/projects/conda/en/latest/user-guide/install/download.html>`_.
+         Miniconda is sufficient for this guide.
+      2. Install Visual C++ build tools following `this guide <https://stackoverflow.com/a/64262038>`_.
+
+         - This is necessary for a dependency of Nextstrain CLI and `we are investigating options to eliminate this step <https://github.com/nextstrain/cli/issues/31#issuecomment-970641263>`_.
+
+      3. Open an Anaconda Prompt, which can be found in the Start menu.
+      4. Create a conda environment named ``nextstrain`` and install the Nextstrain CLI:
+
+         .. code-block:: none
+
+            conda create -n nextstrain -c bioconda nextstrain-cli --yes
+            conda activate nextstrain
+
+      5. Install the Nextstrain build/view environment by `installing Docker Desktop with WSL 2 backend <https://docs.docker.com/desktop/windows/wsl/>`_.
+      6. Confirm that the installation worked.
+
+         .. code-block:: none
+
+            nextstrain check-setup --set-default
+
+         The final output from the last command should look like this:
+
+         .. code-block:: none
+
+            Setting default environment to docker.
+
+   .. group-tab:: WSL on Windows
+
+      .. note::
+
+         If you are an experienced user, you can replace ``conda`` with ``pip`` but :doc:`note the extra installation steps for augur <augur:installation/installation>` and :doc:`install auspice via npm <auspice:introduction/install>`.
+
+      1. `Install WSL 2 <https://docs.microsoft.com/en-us/windows/wsl/install>`_.
+      2. Open a WSL terminal by running **wsl** from the Start menu.
+      3. Install Miniconda:
+
+         .. code-block:: bash
+
+            wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
+            bash Miniconda3-latest-Linux-x86_64.sh
+            rm Miniconda3-latest-Linux-x86_64.sh
+
+      4. Create a conda environment named ``nextstrain`` and install the Nextstrain CLI:
+
+         .. code-block:: bash
+
+            conda create -n nextstrain -c bioconda nextstrain-cli --yes
+            conda activate nextstrain
+
+      5. Install the Nextstrain build/view environment. There are two options:
+
+         a. Docker (recommended) – on Windows, `install Docker Desktop for WSL 2 backend <https://docs.docker.com/desktop/windows/wsl/>`_.
+
+            - Make sure to follow through the last step of enabling **WSL Integration**.
+
+         b. Native – install all the necessary software using conda:
+
+            .. code-block:: bash
+
+                  conda install -c conda-forge -c bioconda augur auspice snakemake --yes
+
+      6. Confirm that the installation worked.
+
+         .. code-block:: bash
+
+            nextstrain check-setup --set-default
+
+         The final output from the last command should look like this, where ``<option>`` is the environment chosen in the previous step:
+
+         .. code-block:: none
+
+            Setting default environment to <option>.
+
+Optionally, :doc:`configure the AWS Batch build environment <cli:aws-batch>` to run the build step on AWS.
+
+Next, try :doc:`tutorials/quickstart`.
+
 .. note::
 
-    If you use Microsoft Windows, `install the Windows Subsystem for Linux (WSL) <https://docs.microsoft.com/en-us/windows/wsl/install-win10>`_.
-    Follow `instructions to open a new WSL window for your Linux distribution <https://docs.microsoft.com/en-us/windows/wsl/wsl-config>`_ and then run the following commands.
+   Whenever you open a new terminal window to work on a Nextstrain analysis, remember to activate the conda environment with ``conda activate nextstrain``.
 
-`Install Miniconda with Python 3 for your operating system <https://docs.conda.io/en/latest/miniconda.html>`_ and then update Conda to the latest version.
+Update an existing installation
+================================
+
+Update the `nextstrain` conda environment.
 
 .. code-block:: bash
 
-    conda update -n base conda
+   conda activate nextstrain
+   conda update --all
 
-Install Nextstrain with Conda or Docker
-=======================================
+[Docker] Download the latest image with the Nextstrain CLI.
 
-Next, decide whether you prefer to install Nextstrain with Conda or Docker.
-We recommend Conda for M1 Mac and Windows users.
-Docker is not yet ready for widespread use on the M1 Mac.
-Similarly, there are still significant obstacles to running Docker with Windows, as documented in `our issue tracking the problems <https://github.com/nextstrain/cli/issues/31>`_.
+.. code-block:: bash
 
-.. tabs::
-
-   .. group-tab:: Conda
-
-      Create a Conda environment named ``nextstrain``.
-      This command will install Nextstrain and its dependencies.
-
-      .. code-block:: bash
-
-         conda create -n nextstrain -c conda-forge -c bioconda \
-           augur auspice nextstrain-cli nextalign snakemake awscli git pip
-
-      Confirm that the installation worked.
-
-      .. code-block:: bash
-
-         conda activate nextstrain
-         nextstrain check-setup --set-default
-
-      The final output from the last command should look like this:
-
-      .. code-block:: bash
-
-         Setting default environment to native.
-
-      Whenever you open a new terminal window to work on a Nextstrain analysis, remember to activate the Nextstrain Conda environment with ``conda activate nextstrain``.
-      Next, try :doc:`tutorials/quickstart`.
-
-   .. group-tab:: Docker
-
-    `Docker <https://docker.com/>`_ is a container system freely-available for all platforms.
-    When you use the Nextstrain CLI with Docker, you don’t need to manage any other Nextstrain software dependencies as validated versions are already bundled into `a container image by the Nextstrain team <https://github.com/nextstrain/docker-base/>`_.
-
-    First, `follow Docker's installation guide <https://docs.docker.com/engine/install/>`_ for your operating system.
-    After installing and starting Docker, create a Conda environment named ``nextstrain``.
-    This command will install the Nextstrain CLI and Git (a dependency of subsequent tutorials).
-
-    .. code-block:: bash
-
-        conda create -n nextstrain -c conda-forge -c bioconda nextstrain-cli git
-
-    Confirm that the installation worked and configure the CLI to use Docker as the default environment manager.
-
-    .. code-block:: bash
-
-        conda activate nextstrain
-        nextstrain check-setup --set-default
-
-    The final output from the last command should look like this:
-
-    .. code-block:: bash
-
-        Setting default environment to docker.
-
-    Finally, download the latest Docker image for Nextstrain.
-
-    .. code-block:: bash
-
-        nextstrain update
-
-    Whenever you open a new terminal window to work on a Nextstrain analysis, remember to activate the Nextstrain Conda environment with ``conda activate nextstrain``.
-    Next, try :doc:`tutorials/quickstart`.
-
-Upgrade an existing installation
-================================
-
-.. tabs::
-
-   .. group-tab:: Conda
-
-      Update the base Conda environment.
-
-      .. code-block:: bash
-
-         conda update -n base conda
-
-      Update the Nextstrain environment.
-
-      .. code-block:: bash
-
-         conda activate nextstrain
-         conda update --all
-
-   .. group-tab:: Docker
-
-      Update the base Conda environment.
-
-      .. code-block:: bash
-
-         conda update -n base conda
-
-      Update the Nextstrain CLI package.
-
-      .. code-block:: bash
-
-         conda activate nextstrain
-         conda update nextstrain-cli
-
-      Download the latest image with the Nextstrain CLI.
-
-      .. code-block:: bash
-
-         nextstrain update
+   nextstrain update
 
 Troubleshoot a broken installation
 ==================================

--- a/src/install.rst
+++ b/src/install.rst
@@ -31,7 +31,7 @@ Conda provides an appropriate version of Python required by all approaches to in
 As a result, mamba can install conda packages much faster and more accurately than the original conda installer.
 
 `Docker <https://docker.com/>`_ is a container system freely-available for all platforms.
-When you use the Docker build/view environment, you don’t need to manage any other Nextstrain software dependencies as validated versions are already bundled into `a container image by the Nextstrain team <https://github.com/nextstrain/docker-base/>`_.
+When you use Docker to run Nextstrain components, you don’t need to manage any other Nextstrain software dependencies as validated versions are already bundled into `a container image by the Nextstrain team <https://github.com/nextstrain/docker-base/>`_.
 
 Installation Steps
 ==================
@@ -87,7 +87,7 @@ These instructions will install the Nextstrain CLI and tools to run and view you
 
       .. note::
 
-         Due to installation constraints, there is no way to use the native build/view environment on Windows directly. Follow steps for **WSL on Windows** if the native environment is desired.
+         Due to installation constraints, there is no way to use the native Nextstrain components on Windows directly. Follow steps for **WSL on Windows** if the native environment is desired.
 
       1. `Install Miniconda <https://docs.conda.io/en/latest/miniconda.html>`_.
       2. Install Visual C++ build tools following `this guide <https://stackoverflow.com/a/64262038>`_.

--- a/src/install.rst
+++ b/src/install.rst
@@ -27,6 +27,9 @@ Background
 `Conda <https://docs.conda.io/en/latest/>`_ is a package and environment management system that allows you to install Python and other software into controlled environments without disrupting other software you have installed (e.g., on your computer, your shared cluster, etc.).
 Conda provides an appropriate version of Python required by all approaches to installing Nextstrain tools.
 
+`Mamba <https://github.com/mamba-org/mamba>`_ is a drop-in replacement for most ``conda`` functionality that implements a faster dependency solving algorithm in C++ and multithreaded downloads.
+As a result, mamba can install conda packages much faster and more accurately than the original conda installer.
+
 `Docker <https://docker.com/>`_ is a container system freely-available for all platforms.
 When you use the Docker build/view environment, you don’t need to manage any other Nextstrain software dependencies as validated versions are already bundled into `a container image by the Nextstrain team <https://github.com/nextstrain/docker-base/>`_.
 
@@ -45,23 +48,30 @@ These instructions will install the Nextstrain CLI and tools to run and view you
 
       1. `Install Miniconda <https://docs.conda.io/projects/conda/en/latest/user-guide/install/download.html>`_.
       2. Open a terminal window.
-      3. Create a conda environment named ``nextstrain`` and install the Nextstrain CLI:
+      3. Install mamba on the ``base`` conda environment:
 
          .. code-block:: bash
 
-            conda create -n nextstrain -c bioconda nextstrain-cli --yes
+            conda install -n base -c conda-forge mamba --yes
+            conda activate base
+
+      4. Create a conda environment named ``nextstrain`` and install the Nextstrain CLI:
+
+         .. code-block:: bash
+
+            mamba create -n nextstrain -c bioconda nextstrain-cli --yes
             conda activate nextstrain
 
-      4. Install the remaining Nextstrain components. There are two options:
+      5. Install the remaining Nextstrain components. There are two options:
 
          a. Docker (recommended) – install Docker Desktop using `the official guide <https://docs.docker.com/desktop/mac/install/>`_.
-         b. Native – install all the necessary software using conda:
+         b. Native – install all the necessary software using mamba:
 
             .. code-block:: bash
 
-               conda install -c conda-forge -c bioconda augur auspice snakemake --yes
+               mamba install -c conda-forge -c bioconda augur auspice snakemake --yes
 
-      5. Confirm that the installation worked.
+      6. Confirm that the installation worked.
 
          .. code-block:: bash
 
@@ -85,15 +95,22 @@ These instructions will install the Nextstrain CLI and tools to run and view you
          - This is necessary for a dependency of Nextstrain CLI and `we are investigating options to eliminate this step <https://github.com/nextstrain/cli/issues/31#issuecomment-970641263>`_.
 
       3. Open an Anaconda Prompt, which can be found in the Start menu.
-      4. Create a conda environment named ``nextstrain`` and install the Nextstrain CLI:
+      4. Install mamba on the ``base`` conda environment:
+
+         .. code-block:: bash
+
+            conda install -n base -c conda-forge mamba --yes
+            conda activate base
+
+      5. Create a conda environment named ``nextstrain`` and install the Nextstrain CLI:
 
          .. code-block:: none
 
-            conda create -n nextstrain -c bioconda nextstrain-cli --yes
+            mamba create -n nextstrain -c bioconda nextstrain-cli --yes
             conda activate nextstrain
 
-      5. Install the remaining Nextstrain components by `installing Docker Desktop with WSL 2 backend <https://docs.docker.com/desktop/windows/wsl/>`_.
-      6. Confirm that the installation worked.
+      6. Install the remaining Nextstrain components by `installing Docker Desktop with WSL 2 backend <https://docs.docker.com/desktop/windows/wsl/>`_.
+      7. Confirm that the installation worked.
 
          .. code-block:: none
 
@@ -122,26 +139,33 @@ These instructions will install the Nextstrain CLI and tools to run and view you
             # follow through installation prompts
             rm Miniconda3-latest-Linux-x86_64.sh
 
-      4. Create a conda environment named ``nextstrain`` and install the Nextstrain CLI:
+      4. Install mamba on the ``base`` conda environment:
 
          .. code-block:: bash
 
-            conda create -n nextstrain -c bioconda nextstrain-cli --yes
+            conda install -n base -c conda-forge mamba --yes
+            conda activate base
+
+      5. Create a conda environment named ``nextstrain`` and install the Nextstrain CLI:
+
+         .. code-block:: bash
+
+            mamba create -n nextstrain -c bioconda nextstrain-cli --yes
             conda activate nextstrain
 
-      5. Install the remaining Nextstrain components. There are two options:
+      6. Install the remaining Nextstrain components. There are two options:
 
          a. Docker (recommended) – on Windows, `install Docker Desktop for WSL 2 backend <https://docs.docker.com/desktop/windows/wsl/>`_.
 
             - Make sure to follow through the last step of enabling **WSL Integration**.
 
-         b. Native – install all the necessary software using conda:
+         b. Native – install all the necessary software using mamba:
 
             .. code-block:: bash
 
-               conda install -c conda-forge -c bioconda augur auspice snakemake --yes
+               mamba install -c conda-forge -c bioconda augur auspice snakemake --yes
 
-      6. Confirm that the installation worked.
+      7. Confirm that the installation worked.
 
          .. code-block:: bash
 
@@ -168,14 +192,21 @@ These instructions will install the Nextstrain CLI and tools to run and view you
             # follow through installation prompts
             rm Miniconda3-latest-Linux-x86_64.sh
 
-      2. Create a conda environment named ``nextstrain`` and install the Nextstrain CLI:
+      2. Install mamba on the ``base`` conda environment:
 
          .. code-block:: bash
 
-            conda create -n nextstrain -c bioconda nextstrain-cli --yes
+            conda install -n base -c conda-forge mamba --yes
+            conda activate base
+
+      3. Create a conda environment named ``nextstrain`` and install the Nextstrain CLI:
+
+         .. code-block:: bash
+
+            mamba create -n nextstrain -c bioconda nextstrain-cli --yes
             conda activate nextstrain
 
-      3. Install the remaining Nextstrain components. There are two options:
+      4. Install the remaining Nextstrain components. There are two options:
 
          a. Docker (recommended):
 
@@ -200,13 +231,13 @@ These instructions will install the Nextstrain CLI and tools to run and view you
 
                   conda activate nextstrain
 
-         b. Native – install all the necessary software using conda:
+         b. Native – install all the necessary software using mamba:
 
             .. code-block:: bash
 
-                  conda install -c conda-forge -c bioconda augur auspice snakemake --yes
+                  mamba install -c conda-forge -c bioconda augur auspice snakemake --yes
 
-      4. Confirm that the installation worked.
+      5. Confirm that the installation worked.
 
          .. code-block:: bash
 
@@ -233,8 +264,9 @@ Update the `nextstrain` conda environment.
 
 .. code-block:: bash
 
+   mamba update -n base conda mamba
    conda activate nextstrain
-   conda update --all
+   mamba update --all -c conda-forge -c bioconda
 
 [Docker] Download the latest image with the Nextstrain CLI.
 
@@ -260,36 +292,6 @@ To start over with a new Nextstrain environment, delete your current environment
     conda env remove -n nextstrain
 
 Then, repeat the installation instructions above, starting with the update of Conda itself.
-
-Use Mamba as an alternative to Conda's environment solver
----------------------------------------------------------
-
-`Mamba <https://github.com/mamba-org/mamba>`_ is a drop-in replacement for most ``conda`` functionality that implements a faster dependency solving algorithm in C++ and multithreaded downloads.
-As a result, Mamba can install Conda packages much faster and more accurately than the original Conda installer.
-
-To try it out, install Mamba.
-
-.. code-block:: bash
-
-    conda install -n base -c conda-forge mamba
-
-Then, use Mamba to create the Nextstrain environment.
-
-.. code-block:: bash
-
-    mamba create -n nextstrain -c conda-forge -c bioconda \
-      augur auspice nextstrain-cli nextalign snakemake awscli git pip
-
-Similarly, use Mamba to update an existing Nextstrain environment to the latest versions of its tools.
-
-.. code-block:: bash
-
-    # Update Conda and Mamba.
-    mamba update -n base conda mamba
-    # Update tools in the Nextstrain environment.
-    conda activate nextstrain
-    mamba update --all -c conda-forge -c bioconda
-
 
 Next steps
 ==========

--- a/src/install.rst
+++ b/src/install.rst
@@ -128,6 +128,7 @@ There are two components to install and configure. These are all the possible co
 
             wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
             bash Miniconda3-latest-Linux-x86_64.sh
+            # follow through installation prompts
             rm Miniconda3-latest-Linux-x86_64.sh
 
       4. Create a conda environment named ``nextstrain`` and install the Nextstrain CLI:

--- a/src/install.rst
+++ b/src/install.rst
@@ -155,6 +155,71 @@ These instructions will install the Nextstrain CLI and tools to run and view you
 
             Setting default environment to <option>.
 
+   .. group-tab:: Ubuntu Linux
+
+      .. note::
+
+         If you are an experienced user, you can replace ``conda`` with ``pip`` but :doc:`note the extra installation steps for augur <augur:installation/installation>` and :doc:`install auspice via npm <auspice:introduction/install>`.
+
+      1. Install Miniconda:
+
+         .. code-block:: bash
+
+            wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
+            bash Miniconda3-latest-Linux-x86_64.sh
+            # follow through installation prompts
+            rm Miniconda3-latest-Linux-x86_64.sh
+
+      2. Create a conda environment named ``nextstrain`` and install the Nextstrain CLI:
+
+         .. code-block:: bash
+
+            conda create -n nextstrain -c bioconda nextstrain-cli --yes
+            conda activate nextstrain
+
+      3. Install the remaining Nextstrain components. There are two options:
+
+         a. Docker (recommended):
+
+            1. Install Docker Engine for Ubuntu using the `convenience script <https://docs.docker.com/engine/install/ubuntu/#install-using-the-convenience-script>`_:
+
+               .. code-block:: bash
+
+                  curl -fsSL https://get.docker.com -o get-docker.sh
+                  sudo sh get-docker.sh
+                  # follow through installation prompts
+                  rm get-docker.sh
+
+            2. Add your user to the `docker` group:
+
+               .. code-block:: bash
+
+                  sudo usermod -aG docker $USER
+
+            3. Restart your machine and activate the conda environment:
+
+               .. code-block:: bash
+
+                  conda activate nextstrain
+
+         b. Native – install all the necessary software using conda:
+
+            .. code-block:: bash
+
+                  conda install -c conda-forge -c bioconda augur auspice snakemake --yes
+
+      4. Confirm that the installation worked.
+
+         .. code-block:: bash
+
+            nextstrain check-setup --set-default
+
+         The final output from the last command should look like this, where ``<option>`` is the option chosen in the previous step:
+
+         .. code-block:: none
+
+            Setting default environment to <option>.
+
 Optionally, :doc:`configure AWS Batch <cli:aws-batch>` if you'd like to run ``nextstrain build`` on AWS.
 
 Next, try :doc:`tutorials/quickstart`.

--- a/src/install.rst
+++ b/src/install.rst
@@ -46,7 +46,12 @@ These instructions will install the Nextstrain CLI and tools to run and view you
 
          If you are an experienced user, you can replace ``conda`` with ``pip`` but :doc:`note the extra installation steps for augur <augur:installation/installation>` and :doc:`install auspice via npm <auspice:introduction/install>`.
 
-      1. `Install Miniconda <https://docs.conda.io/en/latest/miniconda.html>`_.
+      1. Install Miniconda:
+
+         a. Go to the `installation page <https://docs.conda.io/en/latest/miniconda.html>`_.
+         b. Scroll down to the **Latest Miniconda Installer Links** section and click the MacOSX platform link that ends with **pkg**.
+         c. Open the downloaded file and follow through installation prompts.
+
       2. Open a terminal window.
       3. Install mamba on the ``base`` conda environment:
 
@@ -89,12 +94,23 @@ These instructions will install the Nextstrain CLI and tools to run and view you
 
          Due to installation constraints, there is no way to use the native Nextstrain components on Windows directly. Follow steps for **WSL on Windows** if the native environment is desired.
 
-      1. `Install Miniconda <https://docs.conda.io/en/latest/miniconda.html>`_.
-      2. Install Visual C++ build tools following `this guide <https://stackoverflow.com/a/64262038>`_.
+      1. Install Miniconda:
 
-         - This is necessary for a dependency of Nextstrain CLI and `we are investigating options to eliminate this step <https://github.com/nextstrain/cli/issues/31#issuecomment-970641263>`_.
+         a. Go to the `installation page <https://docs.conda.io/en/latest/miniconda.html>`_.
+         b. Scroll down to the **Latest Miniconda Installer Links** section and click the Windows platform link relevant to your machine.
+         c. Open the downloaded file and follow through installation prompts.
 
-      3. Open an Anaconda Prompt, which can be found in the Start menu.
+      2. Install Visual C++ build tools (`we are investigating options to eliminate this step <https://github.com/nextstrain/cli/issues/31>`_):
+
+         a. Go to `this page <https://visualstudio.microsoft.com/visual-cpp-build-tools/>`_ and click the download button.
+         b. Open the download file and follow through installation prompts.
+         c. Once the Visual Studio Installer opens, click **Modify** next to **Launch**, **More**, etc.
+         d. Select **Desktop development with C++**.
+         e. Go to the Individual components tab.
+         f. Search for and select **Windows 10 SDK** and the entry that ends with **C++ x64/x86 build tools (Latest)**.
+         g. Click **Modify** and follow through prompts.
+
+      3. Open an Anaconda PowerShell Prompt, which can be found in the Start menu.
       4. Install mamba on the ``base`` conda environment:
 
          .. code-block:: bash

--- a/src/install.rst
+++ b/src/install.rst
@@ -14,7 +14,7 @@ The following instructions describe how to install Nextstrain's software tools, 
 
 .. note::
 
-    If you want to :doc:`contribute to the development of Nextstrain </guides/contribute/index>` or if you prefer to manage your own custom environment (e.g., a Conda environment, Docker image, environment modules on a cluster, etc.), see the individual installation documentation for :doc:`Nextstrain CLI <cli:installation>`, :doc:`Augur <augur:installation/installation>`, and :doc:`Auspice <auspice:introduction/install>`.
+    If you want to :doc:`contribute to the development of Nextstrain </guides/contribute/index>` or if you prefer to manage your own custom environment (e.g., a conda environment, Docker image, environment modules on a cluster, etc.), see the individual installation documentation for :doc:`Nextstrain CLI <cli:installation>`, :doc:`Augur <augur:installation/installation>`, and :doc:`Auspice <auspice:introduction/install>`.
 
 .. contents:: Table of Contents
    :local:
@@ -277,13 +277,13 @@ Update the `nextstrain` conda environment.
 Troubleshoot a broken installation
 ==================================
 
-If Conda fails to install or update Nextstrain using the commands above, it's possible that Conda itself is out-of-date or that Conda cannot figure out how to resolve the environment's dependencies.
+If conda fails to install or update Nextstrain using the commands above, it's possible that conda itself is out-of-date or that conda cannot figure out how to resolve the environment's dependencies.
 Try the following approaches, to fix these broken installations.
 
 Remove your environment and start from scratch
 ----------------------------------------------
 
-Starting from scratch often fixes problems with Conda environments.
+Starting from scratch often fixes problems with conda environments.
 To start over with a new Nextstrain environment, delete your current environment.
 
 .. code-block:: bash
@@ -291,7 +291,7 @@ To start over with a new Nextstrain environment, delete your current environment
     conda activate base
     conda env remove -n nextstrain
 
-Then, repeat the installation instructions above, starting with the update of Conda itself.
+Then, repeat the installation instructions above, starting with the update of conda itself.
 
 Next steps
 ==========

--- a/src/install.rst
+++ b/src/install.rst
@@ -43,8 +43,7 @@ These instructions will install the Nextstrain CLI and tools to run and view you
 
          If you are an experienced user, you can replace ``conda`` with ``pip`` but :doc:`note the extra installation steps for augur <augur:installation/installation>` and :doc:`install auspice via npm <auspice:introduction/install>`.
 
-      1. Install `Anaconda or Miniconda <https://docs.conda.io/projects/conda/en/latest/user-guide/install/download.html>`_.
-         Miniconda is sufficient for this guide.
+      1. `Install Miniconda <https://docs.conda.io/projects/conda/en/latest/user-guide/install/download.html>`_.
       2. Open a terminal window.
       3. Create a conda environment named ``nextstrain`` and install the Nextstrain CLI:
 
@@ -80,8 +79,7 @@ These instructions will install the Nextstrain CLI and tools to run and view you
 
          Due to installation constraints, there is no way to use the native build/view environment on Windows directly. Follow steps for **WSL on Windows** if the native environment is desired.
 
-      1. Install `Anaconda or Miniconda <https://docs.conda.io/projects/conda/en/latest/user-guide/install/download.html>`_.
-         Miniconda is sufficient for this guide.
+      1. `Install Miniconda <https://docs.conda.io/projects/conda/en/latest/user-guide/install/download.html>`_.
       2. Install Visual C++ build tools following `this guide <https://stackoverflow.com/a/64262038>`_.
 
          - This is necessary for a dependency of Nextstrain CLI and `we are investigating options to eliminate this step <https://github.com/nextstrain/cli/issues/31#issuecomment-970641263>`_.


### PR DESCRIPTION
Preview: https://nextstrain--81.org.readthedocs.build/en/81/install.html

After experimenting with Nextstrain installation on different operating systems, there were notable differences that warranted sectioning the guide per OS.

This change rewrites the installation steps with a grouping of tabs per tested OS.

A new Background section is added before installation steps, retaining notable context from the current documentation.