### PR TITLE
Auto-detect current year for copyright text

### DIFF
--- a/src/conf.py
+++ b/src/conf.py
@@ -21,8 +21,9 @@ subprocess.check_call([sys.executable or "python", './fetch-docs.py'])
 
 # -- Project information -----------------------------------------------------
 
+from datetime import datetime
 project = 'Nextstrain'
-copyright = '2021, Trevor Bedford and Richard Neher'
+copyright = f'{datetime.now().year}, Trevor Bedford and Richard Neher'
 author = 'The Nextstrain Team'
 
 


### PR DESCRIPTION
This change pulls the current year from [`datetime.now()`](https://docs.python.org/3/library/datetime.html#datetime.datetime.now) for the copyright text.