### PR TITLE
Manage RTD redirects using a file in this repo

### DIFF
--- a/.github/workflows/sync-redirects.yaml
+++ b/.github/workflows/sync-redirects.yaml
@@ -1,0 +1,30 @@
+name: Sync RTD redirects
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - redirects.yml
+      - .github/workflows/sync-redirects.yaml
+
+  # Manually triggered using GitHub's UI
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+
+      - name: Upgrade Python toolchain
+        run: python3 -m pip install --upgrade pip setuptools wheel
+
+      - name: Install readthedocs-cli
+        run: python3 -m pip install readthedocs-cli
+
+      - name: Sync redirects
+        run: rtd projects nextstrain redirects sync -f redirects.yml --wet-run
+        env:
+          RTD_TOKEN: ${{ secrets.RTD_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -56,18 +56,14 @@ It uses [our readthedocs.yml](https://github.com/nextstrain/docs.nextstrain.org/
 You can adjust settings for the live version of the docs on [the Read The Docs dashboard for this project](https://readthedocs.org/dashboard/nextstrain/edit/). 
 This includes:
 
-#### Configuring [redirects](https://docs.readthedocs.io/en/stable/user-defined-redirects.html)
-To do this you must choose the following options for the redirect in [the redirects tab for this project](https://readthedocs.org/dashboard/nextstrain/redirects/):
-- type of redirect (we often use "Page redirects" when a page has been moved or we want to point from an old page to a new one)
-- From URL
-- To URL
+#### Configuring redirects
 
-Here is an example:
-```
-Page Redirect
-From URL: /install-nextstrain.html
-To URL: /install.html
-````
+Read The Docs supports [user-defined redirects](https://docs.readthedocs.io/en/stable/user-defined-redirects.html) which we make use of when moving doc pages.
+Putting redirects in place ensures that people don't get lost when following saved links.
+
+Redirects for this RTD project are exclusively defined in the [_redirects.yml_](redirects.yml) file in this repo and synced to RTD using a [GitHub Actions workflow](.github/workflows/sync-redirects.yaml).
+Syncing happens automatically on any push to `master` which changes the file.
+If you need to sync on demand, you can [manually trigger a workflow run](https://github.com/nextstrain/docs.nextstrain.org/actions/workflows/sync-redirects.yaml) or run the `rtd` command in the workflow on your local machine.
 
 A useful tip for Page redirects is that you may configure them while the From URL still is a valid page.
 This won't do anything until that page begins returning a 404, at which point the redirect will take effect.

--- a/redirects.yml
+++ b/redirects.yml
@@ -1,0 +1,156 @@
+# Authoritative list of redirects we have configured in RTD.  See this repo's
+# README.md¹ for more information on maintaining redirects.
+#
+# ¹ https://github.com/nextstrain/docs.nextstrain.org#configuring-redirects
+---
+- type: page
+  from_url: /reference/formats/
+  to_url: /reference/data-formats.html
+
+- type: page
+  from_url: /reference/
+  to_url: /
+
+- type: page
+  from_url: /guides/
+  to_url: /
+
+- type: page
+  from_url: /tutorials/
+  to_url: /
+
+- type: page
+  from_url: /learn/
+  to_url: /
+
+- type: page
+  from_url: /reference/index.html
+  to_url: /index.html
+
+- type: page
+  from_url: /guides/index.html
+  to_url: /index.html
+
+- type: page
+  from_url: /tutorials/index.html
+  to_url: /index.html
+
+- type: page
+  from_url: /learn/index.html
+  to_url: /index.html
+
+- type: page
+  from_url: /reference/formats/index.html
+  to_url: /reference/data-formats.html
+
+- type: page
+  from_url: /reference/formats/data-formats.html
+  to_url: /reference/data-formats.html
+
+- type: page
+  from_url: /learn/about-nextstrain.html
+  to_url: /learn/about.html
+
+- type: page
+  from_url: /install-nextstrain.html
+  to_url: /install.html
+
+- type: page
+  from_url: /tutorials/SARS-CoV-2/steps/metadata-fields
+  to_url: https://docs.nextstrain.org/projects/ncov/en/latest/reference/metadata-fields.html
+
+- type: page
+  from_url: /tutorials/SARS-CoV-2/steps/multiple_inputs
+  to_url: https://docs.nextstrain.org/projects/ncov/en/latest/reference/multiple_inputs.html
+
+- type: page
+  from_url: /tutorials/SARS-CoV-2/steps/configuration
+  to_url: https://docs.nextstrain.org/projects/ncov/en/latest/reference/configuration.html
+
+- type: page
+  from_url: /tutorials/SARS-CoV-2/steps/narratives.html
+  to_url: https://docs.nextstrain.org/projects/ncov/en/latest/visualization/narratives.html
+
+- type: page
+  from_url: /tutorials/SARS-CoV-2/steps/interpretation.html
+  to_url: https://docs.nextstrain.org/projects/ncov/en/latest/visualization/interpretation.html
+
+- type: page
+  from_url: /tutorials/SARS-CoV-2/steps/sharing.html
+  to_url: https://docs.nextstrain.org/projects/ncov/en/latest/visualization/sharing.html
+
+- type: page
+  from_url: /tutorials/SARS-CoV-2/steps/naming_clades.html
+  to_url: https://docs.nextstrain.org/projects/ncov/en/latest/advanced/naming_clades.html
+
+- type: page
+  from_url: /tutorials/SARS-CoV-2/steps/customizing-visualization.html
+  to_url: https://docs.nextstrain.org/projects/ncov/en/latest/analysis/customizing-visualization.html
+
+- type: page
+  from_url: /tutorials/SARS-CoV-2/steps/customizing-analysis.html
+  to_url: https://docs.nextstrain.org/projects/ncov/en/latest/analysis/customizing-analysis.html
+
+- type: page
+  from_url: /tutorials/SARS-CoV-2/steps/running.html
+  to_url: https://docs.nextstrain.org/projects/ncov/en/latest/analysis/running.html
+
+- type: page
+  from_url: /tutorials/SARS-CoV-2/steps/orientation-files.html
+  to_url: https://docs.nextstrain.org/projects/ncov/en/latest/analysis/orientation-files.html
+
+- type: page
+  from_url: /tutorials/SARS-CoV-2/steps/orientation-workflow.html
+  to_url: https://docs.nextstrain.org/projects/ncov/en/latest/analysis/orientation-workflow.html
+
+- type: page
+  from_url: /tutorials/SARS-CoV-2/steps/data-prep.html
+  to_url: https://docs.nextstrain.org/projects/ncov/en/latest/analysis/data-prep.html
+
+- type: page
+  from_url: /tutorials/SARS-CoV-2/steps/setup.html
+  to_url: https://docs.nextstrain.org/projects/ncov/en/latest/analysis/setup.html
+
+- type: page
+  from_url: /tutorials/SARS-CoV-2/steps/index.html
+  to_url: https://docs.nextstrain.org/projects/ncov/en/latest/index.html
+
+- type: page
+  from_url: /tutorials/SARS-CoV-2/index.html
+  to_url: https://docs.nextstrain.org/projects/ncov/en/latest/index.html
+
+- type: page
+  from_url: /guides/install/cli-install.html
+  to_url: https://docs.nextstrain.org/projects/cli/en/latest/installation/
+
+- type: page
+  from_url: /guides/install/auspice-install.html
+  to_url: https://docs.nextstrain.org/projects/auspice/en/stable/introduction/install.html
+
+- type: page
+  from_url: /guides/install/augur_install.html
+  to_url: https://docs.nextstrain.org/projects/augur/en/stable/installation/installation.html
+
+- type: page
+  from_url: /guides/install/auspice-install
+  to_url: https://docs.nextstrain.org/projects/auspice/en/stable/introduction/install.html
+
+- type: page
+  from_url: /guides/install/windows-help.html
+  to_url: install-nextstrain.html
+
+- type: page
+  from_url: /guides/install/local-installation.html
+  to_url: install-nextstrain.html
+
+- type: page
+  from_url: /guides/install/index.html
+  to_url: install-nextstrain.html
+
+- type: page
+  from_url: /guides/install/
+  to_url: install-nextstrain.html
+
+- type: page
+  from_url: /tutorials/zika_tutorial.html
+  to_url: /tutorials/zika.html


### PR DESCRIPTION
Automatically synced to RTD using the new readthedocs-cli package I wrote and a new GitHub Actions workflow for this repo.

Includes the `redirects.yml` file I pushed to #84, so it doesn't matter which order merge happens in.

I setup the `RTD_TOKEN` secret on GitHub (using the `nextstrain` RTD user's account) and manually triggered [a test run of the workflow](https://github.com/nextstrain/docs.nextstrain.org/runs/4743056090?check_suite_focus=true). All looks well.