### PR TITLE
Rename CLI term to Nextstrain CLI

### DIFF
--- a/src/learn/parts.rst
+++ b/src/learn/parts.rst
@@ -231,7 +231,7 @@ our core builds, or others' group or community builds.  You can even install
 Auspice on :doc:`your own web server <auspice:server/index>` if you don't want
 to host your datasets via nextstrain.org.
 
-The :term:`Nextstrain CLI<CLI>` ties
+The :term:`Nextstrain CLI` ties
 together all of the above to provide a consistent way to run pathogen workflows,
 access Nextstrain tools like Augur and Auspice across computing environments
 such as Docker, Conda, and AWS Batch, and publish datasets to nextstrain.org.

--- a/src/reference/glossary.rst
+++ b/src/reference/glossary.rst
@@ -73,8 +73,7 @@ Glossary
       Special ``.json`` files produced by :term:`Augur` and visualized by :term:`Auspice`. These files make up a :term:`dataset`.
       See :doc:`data formats<data-formats>`.
 
-   CLI
-      also *Nextstrain CLI*
+   Nextstrain CLI
 
       The Nextstrain command-line interface (**Nextstrain CLI**) provides a consistent way to run and visualize :term:`pathogen builds<Build>` and access Nextstrain components like :term:`Augur` and :term:`Auspice` across :term:`runtimes<runtime>` such as Docker, Native, and AWS Batch.
 
@@ -83,7 +82,7 @@ Glossary
    runtime
       also *Nextstrain runtime*
 
-      When installing and using the :term:`Nextstrain CLI<CLI>`, there are different configuration options, or **runtimes**, depending on the operating system.
+      When installing and using the :term:`Nextstrain CLI`, there are different configuration options, or **runtimes**, depending on the operating system.
 
       1. Docker runtime
       2. Native runtime

--- a/src/tutorials/running-a-workflow.rst
+++ b/src/tutorials/running-a-workflow.rst
@@ -2,7 +2,7 @@
 Running a pathogen workflow
 ===========================
 
-This tutorial uses the :term:`Nextstrain CLI<CLI>` to help you get started running :term:`pathogen workflows<workflow>` and viewing the :term:`datasets<dataset>` you see on `nextstrain.org <https://nextstrain.org>`_.
+This tutorial uses the :term:`Nextstrain CLI` to help you get started running :term:`pathogen workflows<workflow>` and viewing the :term:`datasets<dataset>` you see on `nextstrain.org <https://nextstrain.org>`_.
 It assumes you are comfortable using the command line and installing software on your computer.
 If you need help when following this tutorial, please create a post at `discussion.nextstrain.org <https://discussion.nextstrain.org>`_.
 
@@ -44,7 +44,7 @@ Run the workflow
 
 :term:`Pathogen workflows<workflow>` use the :term:`Augur` bioinformatics toolkit to subsample data, align sequences, build a phylogeny, estimate phylogeographic patterns, and save the results in a format suitable for visualization with :term:`Auspice`.
 
-Run the workflow with the :term:`Nextstrain CLI<CLI>`.
+Run the workflow with the :term:`Nextstrain CLI`.
 
 .. code-block::
 


### PR DESCRIPTION
Following nextstrain/cli#142:

> Avoid confusion with other CLIs now that we have a few.