### PR TITLE
Keep a list of RTD projects and a list of RTD maintainers

### DIFF
--- a/data/rtd-maintainers
+++ b/data/rtd-maintainers
@@ -1,0 +1,9 @@
+corneliusroemer
+huddlej
+ivan.aksamentov
+jameshadfield
+nextstrain
+rneher
+trs
+trvrb
+victorlin0

--- a/data/rtd-projects
+++ b/data/rtd-projects
@@ -1,0 +1,8 @@
+nextstrain
+nextstrain-augur
+nextstrain-auspice
+nextstrain-cli
+nextstrain-ncov
+nextstrain-nextclade
+nextstrain-sphinx-theme
+nextstrain.org


### PR DESCRIPTION
This helps with some manually-run automation like syncing RTD maintainers for each project.

### Related issue(s)
Related to nextstrain/readthedocs-cli#3.

### Testing
Since making the original version of this commit, I've already added one person and used the updated files to re-sync quickly.