### PR TITLE
Replace build term

### DIFF
--- a/src/guides/bioinformatics/defining-clades.md
+++ b/src/guides/bioinformatics/defining-clades.md
@@ -1,6 +1,6 @@
 # Manually Labeling Clades on a Nextstrain Tree
 
-If you look at the [Nextstrain Seasonal Influenza tree](https://nextstrain.org/flu/seasonal/h3n2/ha/3y), you'll see that the clades are labelled (for example, `3c2`, `3c2.A`, `3c3` etc.). However labelled clades are not a default in Nextstrain builds. You may want to add clade labelling to your Nextstrain trees to more easily describe certain aspects of the tree, point out agreed-upon groups that are accepted by the field, or to facilitate zoomed views on the tree when using [Nextstrain narratives](https://nextstrain.org/docs/narratives/introduction). This bit of documentation describes how to add clade labeling to your Nextstrain build.
+If you look at the [Nextstrain Seasonal Influenza tree](https://nextstrain.org/flu/seasonal/h3n2/ha/3y), you'll see that the clades are labelled (for example, `3c2`, `3c2.A`, `3c3` etc.). However labelled clades are not a default in Nextstrain workflows. You may want to add clade labelling to your Nextstrain trees to more easily describe certain aspects of the tree, point out agreed-upon groups that are accepted by the field, or to facilitate zoomed views on the tree when using [Nextstrain narratives](https://nextstrain.org/docs/narratives/introduction). This bit of documentation describes how to add clade labeling to your Nextstrain workflow.
 
 ## Finding Clade Defining Nucleotide Mutations
 
@@ -21,7 +21,7 @@ The header of this TSV file should have the following entries: clade`\t`gene`\t`
 
 * `clade` is the name of your clade, whatever you want to refer to it as.
 
-* `gene` should be entered as `nuc` if you are using nucleotide mutations. If you are using amino acid mutations, it would be the gene the amino acid mutation is in, as that gene is defined within the build.
+* `gene` should be entered as `nuc` if you are using nucleotide mutations. If you are using amino acid mutations, it would be the gene the amino acid mutation is in, as that gene is defined within the workflow.
 
 * `site` is the position in the genome where the mutation occurred.
 

--- a/src/guides/share/community-builds.md
+++ b/src/guides/share/community-builds.md
@@ -4,7 +4,7 @@ One of [the ways](./index) we allow researchers to share their analyses through 
 This allows dataset JSONs and/or narrative markdown files to be stored in your own GitHub repos and accessed through [nextstrain.org/community](https://nextstrain.org/community) URLs.
 This gives you complete control, ownership, and discretion over your data.
 All that is required for this funcitonality is for files to conform to a specific naming scheme (see below).
-There is no need to get in touch with the Nextstrain team to allow access to the dataset, but if you would like your dataset featured on the [front page](https://nextstrain.org/community) or to be listed along with all available [SARS-CoV-2 builds](https://nextstrain.org/sars-cov-2/) then please [let us know!](mailto:hello@nextstrain.org)
+There is no need to get in touch with the Nextstrain team to allow access to the dataset, but if you would like your dataset featured on the [front page](https://nextstrain.org/community) or to be listed along with all available [SARS-CoV-2 datasets](https://nextstrain.org/sars-cov-2/) then please [let us know!](mailto:hello@nextstrain.org)
 
 P.S. For help with running your analysis, [see the bioinformatics introduction](https://docs.nextstrain.org/projects/augur/en/stable/index.html).
 
@@ -59,6 +59,6 @@ See "zika-colombia" in the table below as an example.
 ESR-NZ | GenomicsNarrativeSARSCoV2 | [master](https://github.com/ESR-NZ/GenomicsNarrativeSARSCoV2/tree/master) | [narratives/GenomicsNarrativeSARSCoV2_2020-10-01.md](https://github.com/ESR-NZ/GenomicsNarrativeSARSCoV2/blob/master/narratives/GenomicsNarrativeSARSCoV2_2020-10-01.md) | https://nextstrain.org/community/narratives/ESR-NZ/GenomicsNarrativeSARSCoV2/2020-10-01
 [blab](github.com/blab/) | [ebola-narrative-ms](https://github.com/blab/ebola-narrative-ms/) | master | [narratives/ebola-narrative-ms_2019-09-13-sit-rep-ENGLISH.md](https://github.com/blab/ebola-narrative-ms/blob/master/narratives/ebola-narrative-ms_2019-09-13-sit-rep-ENGLISH.md) | https://nextstrain.org/community/narratives/blab/ebola-narrative-ms/2019-09-13-sit-rep-ENGLISH
 
-For more examples please see the [Nextstrain front page](https://nextstrain.org/community) and the listing of all [SARS-CoV-2 builds](https://nextstrain.org/sars-cov-2/).
+For more examples please see the [Nextstrain front page](https://nextstrain.org/community) and the listing of all [SARS-CoV-2 datasets](https://nextstrain.org/sars-cov-2/).
 
 

--- a/src/guides/share/nextstrain-groups.rst
+++ b/src/guides/share/nextstrain-groups.rst
@@ -70,7 +70,7 @@ Customize your group's page
 You can customize the content of your group's page by uploading two files to the group's S3 bucket:
 
 * ``group-logo.png``: logo to display at the top of the page
-* ``group-overview.md``: a description of your group and the Nextstrain builds your group provides
+* ``group-overview.md``: a description of your group and the Nextstrain datasets your group provides
 
 Create a new file named ``group-overview.md`` that will contain information about your group.
 At the top of this file, provide a title for the page, a list of people who maintain the data, a website, and/or whether to show datasets and narratives from your group.
@@ -104,25 +104,25 @@ Upload your logo and description to your group’s S3 bucket with :doc:`the next
 
 To update your logo, description, or any other data in your group’s S3 bucket, run the ``nextstrain remote upload`` command again and the uploaded data will replace the previous contents in the bucket.
 
-Upload a Nextstrain build
-=========================
+Upload a Nextstrain dataset
+===========================
 
 .. warning::
 
-   Do not upload personally identifiable information (PII) as part of your build data.
+   Do not upload personally identifiable information (PII) as part of your dataset.
    This restriction applies for public and private groups.
 
-Next, upload one or more Nextstrain builds for your group.
+Next, upload one or more :term:`Nextstrain datasets<dataset>` for your group.
 
 .. code-block:: bash
 
    nextstrain remote upload s3://nextstrain-<group>/ \
-     auspice/ncov_<your-build-name>.json \
-     auspice/ncov_<your-build-name>_tip-frequencies.json \
-     auspice/ncov_<your-build-name>_root-sequence.json
+     auspice/ncov_<your-dataset-name>.json \
+     auspice/ncov_<your-dataset-name>_tip-frequencies.json \
+     auspice/ncov_<your-dataset-name>_root-sequence.json
 
-After the upload completes, navigate to your groups page from `https://nextstrain.org/groups/ <https://nextstrain.org/groups/>`_ to see the build you uploaded.
-Alternately, upload multiple build files at once with wildcard syntax.
+After the upload completes, navigate to your groups page from `https://nextstrain.org/groups/ <https://nextstrain.org/groups/>`_ to see the dataset you uploaded.
+Alternately, upload multiple dataset files at once with wildcard syntax.
 
 .. code-block:: bash
 
@@ -140,13 +140,13 @@ For example, the following command removes your group logo and overview files.
    nextstrain remote delete s3://nextstrain-<group>/group-overview.md
 
 Alternately, you can remove multiple files with the same prefix.
-For example, the following command removes all files associated with a specific build's prefix.
+For example, the following command removes all files associated with a specific dataset's prefix.
 
 .. code-block:: bash
 
    nextstrain remote delete \
      --recursively \
-     s3://nextstrain-<group>/ncov_<your-build-name>
+     s3://nextstrain-<group>/ncov_<your-dataset-name>
 
 Learn more about the Nextstrain command line interface
 ======================================================

--- a/src/learn/parts.rst
+++ b/src/learn/parts.rst
@@ -118,7 +118,7 @@ colloquially because they use a generic data format called JSON.
         Augur -> jsons -> Auspice;
     }
 
-:term:`Builds<build>` are recipes of code and data that produce these :term:`datasets<dataset>`.
+:term:`Workflows<workflow>` are recipes of code and data that produce these :term:`datasets<dataset>`.
 
 .. graphviz::
     :align: center
@@ -165,9 +165,9 @@ colloquially because they use a generic data format called JSON.
         metadata -> filter;
     }
 
-Builds run several commands and are often automated by workflow managers such as `Snakemake <https://snakemake.readthedocs.io>`__, `Nextflow <https://nextflow.io>`__ and `WDL <https://openwdl.org>`__. A :term:`workflow` bundles one or more related :term:`builds<build>` which each produce a :term:`dataset` for visualization with :term:`Auspice`.
+Workflows run several commands and are often automated by workflow managers such as `Snakemake <https://snakemake.readthedocs.io>`__, `Nextflow <https://nextflow.io>`__ and `WDL <https://openwdl.org>`__. A :term:`workflow` produces one or more related :term:`datasets<dataset>` for visualization with :term:`Auspice`.
 
-As an example, our core workflows are organized as `Git repositories <https://git-scm.com>`__ hosted on `GitHub <https://github.com/nextstrain>`__. Each contains a :doc:`Snakemake workflow </guides/bioinformatics/augur_snakemake>` using Augur, configuration, and data.
+As an example, our :term:`core workflows<core workflow>` are organized as `Git repositories <https://git-scm.com>`__ hosted on `GitHub <https://github.com/nextstrain>`__. Each contains a :doc:`Snakemake workflow </guides/bioinformatics/augur_snakemake>` using Augur, configuration, and data.
 
 .. graphviz::
     :align: center
@@ -189,31 +189,20 @@ As an example, our core workflows are organized as `Git repositories <https://gi
 
         subgraph cluster_0 {
             label = "Zika workflow";
-            build0 [width=1, label="Zika build"]
-            dataset0 [width=1, label="dataset"]
+            dataset0 [width=1, label="Zika dataset"]
         }
 
         subgraph cluster_1 {
             label = "SARS-CoV-2 workflow";
-            build1 [width=1, label="Global build"]
-            build2 [width=1, label="Africa build"]
-            build3 [width=1, label="Europe build"]
-            dataset1 [width=1, label="dataset"]
-            dataset2 [width=1, label="dataset"]
-            dataset3 [width=1, label="dataset"]
+            dataset1 [width=1, label="Global dataset"]
+            dataset2 [width=1, label="Africa dataset"]
+            dataset3 [width=1, label="Europe dataset"]
             ellipses1 [width=1, label="...", penwidth=0, fillcolor="white"]
-            ellipses2 [width=1, label="...", penwidth=0, fillcolor="white"]
         }
-
-        build0 -> dataset0
-        build1 -> dataset1
-        build2 -> dataset2
-        build3 -> dataset3
 
         {
             edge[style=invis]
-            dataset0 -> build1      // arrange clusters on same row
-            ellipses1 -> ellipses2
+            dataset0 -> dataset1      // arrange clusters on same row
         }
     }
 
@@ -226,8 +215,8 @@ website incorporates a customized version of Auspice for displaying each
 dataset.
 
 You can run :term:`Augur` and :term:`Auspice` on
-your own computer and use them independently or together with your own builds,
-our core builds, or others' group or community builds.  You can even install
+your own computer and use them independently or together with your own workflows,
+our core workflows, or others' group or community builds.  You can even install
 Auspice on :doc:`your own web server <auspice:server/index>` if you don't want
 to host your datasets via nextstrain.org.
 

--- a/src/reference/data-formats.rst
+++ b/src/reference/data-formats.rst
@@ -4,11 +4,11 @@ Data formats
 
 Nextstrain uses a few different kinds of `JSON
 <https://en.wikipedia.org/wiki/JSON>`__ files at various stages in a typical
-build.
+workflow.
 
 The primary JSON files used by Nextstrain are those consumed by Auspice to
 display a dataset.  Without these **dataset files**, Auspice has nothing to
-display.  These files are typically the final output of a build and produced by
+display.  These files are typically the final output of a workflow and produced by
 the Augur command :doc:`augur export <augur:usage/cli/export>`.  They come in
 two versions:
 
@@ -56,9 +56,9 @@ are:
 Node data files have a :doc:`generic structure <augur:usage/json_format>` to
 allow them to contain all kinds of data about your tree.
 
-In advanced builds, custom node data files are often produced by build-specific
+In advanced workflows, custom node data files are often produced by workflow-specific
 scripts in addition to the ones produced by Augur commands.  For example, our
-`ncov build <https://github.com/nextstrain/ncov>`__ produces a custom
+`ncov workflow <https://github.com/nextstrain/ncov>`__ produces a custom
 ``epiweeks.json`` node data file using `this workflow step
 <https://github.com/nextstrain/ncov/blob/cee806f/workflow/snakemake_rules/main_workflow.smk#L1127-L1143>`__
 and `this script

--- a/src/reference/glossary.rst
+++ b/src/reference/glossary.rst
@@ -15,16 +15,7 @@ Glossary
    workflow
       also *pathogen workflow*, *pathogen analysis*, *Nextstrain workflow*
 
-      A reproducible process comprised of one or more :term:`builds<build>` producing :term:`datasets<dataset>`, which can be visualized by :term:`Auspice`. Implementation varies per workflow, but generally they are run by workflow managers such as Snakemake.
-
-      Our :term:`core workflows<core workflow>` can be divided into two types:
-
-      1. Single-build workflow (e.g. Zika workflow): one build producing one dataset.
-      2. Multi-build workflow (e.g. SARS-CoV-2 workflow): multiple builds producing multiple datasets.
-
-      .. note::
-
-         The individual builds in a multi-build workflow are also "workflows" in the definition of workflow managers like Snakemake.
+      A reproducible process producing one or more :term:`datasets<dataset>`, which can be visualized by :term:`Auspice`. Implementation varies per workflow, but generally they are run by workflow managers such as Snakemake.
 
    core workflow
 
@@ -35,23 +26,14 @@ Glossary
 
       A version-controlled folder containing all files necessary to run a :term:`workflow`.
 
-   build
-      also *Nextstrain build*
-
-      *(noun)* A sequence of commands, parameters and input files which work together to reproducibly execute bioinformatic analyses and generate a :term:`dataset` for visualization with :term:`Auspice`.
-
    build (verb)
 
       A general term for running a :term:`workflow` (e.g. ``nextstrain build``).
 
-   build step
-
-      A modular instruction of a :term:`build` which can be run standalone (e.g. ``augur filter``), often with clear input and output files.
-
    dataset
-      also *Auspice JSONs*
+      also *Auspice JSONs, Nextstrain dataset*
 
-      A collection of :term:`JSONs` produced by a :term:`build`. It is also the shared file prefix of the JSONs. For example ``flu/seasonal/h3n2/ha/2y`` identifies a dataset which corresponds to the files
+      A collection of :term:`JSONs` produced by a :term:`workflow`. It is also the shared file prefix of the JSONs. For example ``flu/seasonal/h3n2/ha/2y`` identifies a dataset which corresponds to the files
       :
 
       - ``flu_seasonal_h3n2_ha_2y_meta.json``
@@ -75,7 +57,7 @@ Glossary
 
    Nextstrain CLI
 
-      The Nextstrain command-line interface (**Nextstrain CLI**) provides a consistent way to run and visualize :term:`pathogen builds<Build>` and access Nextstrain components like :term:`Augur` and :term:`Auspice` across :term:`runtimes<runtime>` such as Docker, Native, and AWS Batch.
+      The Nextstrain command-line interface (**Nextstrain CLI**) provides a consistent way to run and visualize :term:`pathogen workflows<workflow>` and access Nextstrain components like :term:`Augur` and :term:`Auspice` across :term:`runtimes<runtime>` such as Docker, Native, and AWS Batch.
 
       :doc:`Documentation <cli:index>`
 

--- a/src/tutorials/creating-a-bacterial-pathogen-workflow.rst
+++ b/src/tutorials/creating-a-bacterial-pathogen-workflow.rst
@@ -2,7 +2,7 @@
 Creating a bacterial pathogen workflow
 ======================================
 
-This tutorial explains how to create a :term:`single-build Nextstrain workflow<workflow>` for Tuberculosis sequences. However, much of it will be applicable to any run where you are starting with `VCF <https://en.wikipedia.org/wiki/Variant_Call_Format>`_ files rather than `FASTA <https://en.wikipedia.org/wiki/FASTA_format>`_ files. We'll create a Snakefile step-by-step for each step of the analysis.
+This tutorial explains how to create a :term:`Nextstrain workflow<workflow>` for Tuberculosis sequences. However, much of it will be applicable to any run where you are starting with `VCF <https://en.wikipedia.org/wiki/Variant_Call_Format>`_ files rather than `FASTA <https://en.wikipedia.org/wiki/FASTA_format>`_ files. We'll create a Snakefile step-by-step for each step of the analysis.
 
 .. contents:: Table of Contents
    :local:
@@ -34,10 +34,10 @@ Setup
 
       The data in this tutorial is public and is a subset of the data from Lee et al.'s 2015 paper `Population genomics of Mycobacterium tuberculosis in the Inuit <http://www.pnas.org/content/112/44/13609>`_. As location was anonymized in the paper, location data provided here was randomly chosen from the region for illustrative purposes.
 
-Create the Nextstrain Build
-===========================
+Create the Nextstrain Workflow
+==============================
 
-This :term:`build` will have the following :term:`steps<build step>`:
+This :term:`workflow` will have the following steps:
 
 .. contents::
    :local:
@@ -45,7 +45,7 @@ This :term:`build` will have the following :term:`steps<build step>`:
 Prepare the Sequences
 ---------------------
 
-A Nextstrain build with VCF file input starts with:
+A Nextstrain workflow with VCF file input starts with:
 
 -  A VCF file containing all the sequences you want to include (variable sites only)
 -  A FASTA file of the reference sequence to which your VCF was mapped
@@ -55,7 +55,7 @@ There are other files you will need if you want to perform certain steps, like m
 
 Here, our input file is compressed with gzip - you can see it ends with ``.vcf.gz``. However, :term:`Augur` can take gzipped or un-gzipped VCF files. It can also produce either gzipped or un-gzipped VCF files as output (detected from the file ending you provide). Here, we'll usually keep our output VCF files gzipped, by giving our output files endings like ``.vcf.gz``, but you can specify ``.vcf`` instead.
 
-All the data you need to make the TB build are in the ``data`` and ``config`` folders.
+All the data you need to make the TB workflow are in the ``data`` and ``config`` folders.
 
 Filter the Sequences
 ~~~~~~~~~~~~~~~~~~~~

--- a/src/tutorials/creating-a-workflow.rst
+++ b/src/tutorials/creating-a-workflow.rst
@@ -2,11 +2,7 @@
 Creating a pathogen workflow
 ============================
 
-This tutorial dissects the :term:`single-build workflow<workflow>` used in the previous tutorial. We will first make the build step-by-step. Then we will automate this stepwise process in a :term:`workflow`.
-
-.. note::
-
-   The difference between a :term:`workflow` and :term:`build` isn't obvious with single-build workflows such as this example Zika workflow, but will become more distinct in multi-build workflows such as the SARS-CoV-2 workflow.
+This tutorial dissects the :term:`workflow` used in the previous tutorial. We will first run steps individually. Then we will automate this stepwise process using a workflow manager.
 
 .. contents:: Table of Contents
    :local:
@@ -49,10 +45,10 @@ Setup
 
       The dot (``.``) as the last argument indicates that your current directory (``zika-tutorial/``) is the working directory. Your command prompt will change to indicate you are in the Docker runtime. If you want to leave the runtime, run the command ``exit``.
 
-Run a Nextstrain Build
-======================
+Run a Nextstrain Workflow
+=========================
 
-:term:`Nextstrain builds<build>` typically require the following steps:
+:term:`Nextstrain workflows<workflow>` typically require the following steps:
 
 .. contents::
    :local:
@@ -61,7 +57,7 @@ Prepare the Sequences
 ---------------------
 
 
-A :term:`Nextstrain build<build>` typically starts with a collection of pathogen sequences in a single `FASTA <https://en.wikipedia.org/wiki/FASTA_format>`_ file and a corresponding table of metadata describing those sequences in a tab-delimited text file. For this tutorial, we will use example data containing 34 virus sequences.
+A :term:`Nextstrain workflows<workflow>` typically starts with a collection of pathogen sequences in a single `FASTA <https://en.wikipedia.org/wiki/FASTA_format>`_ file and a corresponding table of metadata describing those sequences in a tab-delimited text file. For this tutorial, we will use example data containing 34 virus sequences.
 
 Each virus sequence record looks like the following, with the virus's strain ID as the sequence name in the header line followed by the virus sequence.
 
@@ -89,7 +85,7 @@ A metadata file must have the following columns:
 -  Virus
 -  Date
 
-Builds using published data should include the following additional columns, as shown in the example above:
+Workflows using published data should include the following additional columns, as shown in the example above:
 
 -  Accession (e.g., NCBI GenBank, EMBL EBI, etc.)
 -  Authors
@@ -269,10 +265,10 @@ While Auspice is running, navigate to http://127.0.0.1:4000/zika in your browser
 
 To stop Auspice and return to the command line when you are done viewing your data, press CTRL+C.
 
-Automate the Build with Snakemake
-=================================
+Automate the Workflow with Snakemake
+====================================
 
-While it is instructive to run all of the above commands manually, it is more practical to automate their execution with a workflow manager. Nextstrain implements these automated builds with `Snakemake <https://snakemake.readthedocs.io>`_ by defining a ``Snakefile`` like `this Snakefile <https://github.com/nextstrain/zika-tutorial/blob/master/Snakefile>`_ used in the :doc:`previous tutorial <running-a-workflow>`.
+While it is instructive to run all of the above commands manually, it is more practical to automate their execution with a workflow manager. Nextstrain implements these automated workflows with `Snakemake <https://snakemake.readthedocs.io>`_ by defining a ``Snakefile`` like `this Snakefile <https://github.com/nextstrain/zika-tutorial/blob/master/Snakefile>`_ used in the :doc:`previous tutorial <running-a-workflow>`.
 
 From the ``zika-tutorial/`` directory, delete the previously generated results.
 
@@ -280,7 +276,7 @@ From the ``zika-tutorial/`` directory, delete the previously generated results.
 
    rm -rf results/ auspice/
 
-Run the automated build.
+:term:`Build<build (verb)>` the automated workflow.
 
 .. code-block:: bash
 


### PR DESCRIPTION
[_docs preview_](https://nextstrain--101.org.readthedocs.build/en/101/)

### Description of proposed changes

This PR replaces the **_build_** term with either **_workflow_** or **_dataset_**, depending on context.

### Related issue(s)

- #100

### Notes

To truly free up **_build_** from our terminology, the following should change but I'm not sure if we want to pursue:

- _community builds_ → _community datasets_
- `nextstrain build` → `nextstrain run` (?)
- ~ncov: `builds.yaml` → `config.yaml`, `builds:` → `outputs:`~ see https://github.com/nextstrain/docs.nextstrain.org/pull/92#discussion_r826237041

I noticed [local-vs-container.svg](https://github.com/nextstrain/docs.nextstrain.org/blob/a3e57c00e8d04d903e9cfe17a34ae913937bd1c2/src/images/local-vs-container.svg) has references to **_build_**, but I can't find any references to this file. Is it being used?