### PR TITLE
Rework contributing pages

### DIFF
--- a/redirects.yml
+++ b/redirects.yml
@@ -182,3 +182,7 @@
 - type: page
   from_url: /guides/contribute/cli-develop.html
   to_url: https://github.com/nextstrain/cli/tree/master/doc/development.md#readme
+
+- type: page
+  from_url: /guides/contribute/documentation.html
+  to_url: /guides/contribute/index.html

--- a/redirects.yml
+++ b/redirects.yml
@@ -170,3 +170,15 @@
 - type: page
   from_url: /guides/share/nextstrain-groups.html
   to_url: /guides/share/groups/index.html
+
+- type: page
+  from_url: /guides/contribute/augur_develop.html
+  to_url: https://github.com/nextstrain/augur/tree/master/docs/contribute/DEV_DOCS.md#readme
+
+- type: page
+  from_url: /guides/contribute/auspice-develop.html
+  to_url: https://github.com/nextstrain/auspice/tree/master/DEV_DOCS.md#readme
+
+- type: page
+  from_url: /guides/contribute/cli-develop.html
+  to_url: https://github.com/nextstrain/cli/tree/master/doc/development.md#readme

--- a/src/fetch-docs.py
+++ b/src/fetch-docs.py
@@ -10,13 +10,9 @@ auspice_branch = 'master'
 auspice_base_url = f'https://raw.githubusercontent.com/nextstrain/auspice/{auspice_branch}/'
 auspice_url = f'{auspice_base_url}docs/'
 
-cli_branch = 'master'
-cli_url = f'https://raw.githubusercontent.com/nextstrain/cli/{cli_branch}/doc/'
-
 docs = {
     f'{auspice_url}narratives/create-pdf.md': 'guides/communicate/create-pdf.md',
     f'{auspice_url}narratives/introduction.md': 'guides/communicate/narratives-intro.md',
-    f'{auspice_base_url}DEV_DOCS.md': 'guides/contribute/auspice-develop.md',
     f'{auspice_url}narratives/how-to-write.md': 'tutorials/narratives-how-to-write.md',
     f'{augur_url}usage/augur_snakemake.md': 'guides/bioinformatics/augur_snakemake.md',
     f'{augur_url}faq/translate_ref.md': 'guides/bioinformatics/translate_ref.md',
@@ -27,8 +23,6 @@ docs = {
     f'{augur_url}faq/fasta_input.md': 'guides/bioinformatics/fasta_input.md',
     f'{augur_url}faq/seq_traits.md': 'guides/bioinformatics/seq_traits.md',
     f'{augur_url}examples/examples.rst': 'guides/bioinformatics/examples.rst',
-    f'{augur_url}contribute/DEV_DOCS.md':   'guides/contribute/augur_develop.md',
-    f'{cli_url}development.md': 'guides/contribute/cli-develop.md'
 }
 
 if __name__ == '__main__':

--- a/src/guides/contribute/documentation.md
+++ b/src/guides/contribute/documentation.md
@@ -1,4 +1,0 @@
-# Contributing to Documentation
-
-For now, please use [the README for this project on github](https://github.com/nextstrain/docs.nextstrain.org#docsnextstrainorg) as your guide to contributing documentation to this site.
-Thank you for contributing to Nextstrain documentation!

--- a/src/guides/contribute/index.rst
+++ b/src/guides/contribute/index.rst
@@ -1,18 +1,19 @@
-
-======================================
+==========================
 Contributing to Nextstrain
-======================================
+==========================
 
-How-to guides for contributing to Nextstrain.
-Please read the `Nextstrain Github Contributing Guide <https://github.com/nextstrain/.github/blob/master/CONTRIBUTING.md>`__ before contributing to any part of Nextstrain.
+There are many ways to contribute to Nextstrain, and we welcome all contributors!
+Read our `Contributing Guide <https://github.com/nextstrain/.github/blob/master/CONTRIBUTING.md#readme>`__ to learn about the kinds of contributions you can make and how to get started.
+Please read our `Code of Conduct <https://github.com/nextstrain/.github/blob/master/CODE_OF_CONDUCT.md#readme>`__ before starting.
 
-.. toctree::
-   :maxdepth: 2
-   :titlesonly:
-   :caption: Table of contents
+You'll find all our source code repositories used for development within the `Nextstrain GitHub organization <https://github.com/nextstrain>`__.
+How-to guides for contributing source code modifications to our projects are kept in each project's respository, sometimes as part of the :file:`README.md`, sometimes as a separate document.
+For example:
 
-   Nextstrain Github Contributing Guide <https://github.com/nextstrain/.github/blob/master/CONTRIBUTING.md>
-   documentation
-   Contribute to Nextstrain CLI <https://github.com/nextstrain/cli/tree/master/doc/development.md#readme>
-   Contribute to Augur <https://github.com/nextstrain/augur/tree/master/docs/contribute/DEV_DOCS.md#readme>
-   Contribute to Auspice <https://github.com/nextstrain/auspice/tree/master/DEV_DOCS.md#readme>
+- `Augur development guide <https://github.com/nextstrain/augur/tree/master/docs/contribute/DEV_DOCS.md#readme>`__
+- `Auspice development guide <https://github.com/nextstrain/auspice/tree/master/DEV_DOCS.md#readme>`__
+- `Nextstrain CLI development guide <https://github.com/nextstrain/cli/tree/master/doc/development.md#readme>`__
+- `nextstrain.org README <https://github.com/nextstrain/nextstrain.org/blob/master/README.md#readme>`__ (main website)
+- `docs.nextstrain.org README <https://github.com/nextstrain/docs.nextstrain.org/blob/master/README.md#readme>`__ (documentation website)
+
+All of these guides generally assume you're working within the context of a local copy of the given repository and are familiar with the command line and the Git version control system.

--- a/src/guides/contribute/index.rst
+++ b/src/guides/contribute/index.rst
@@ -13,6 +13,6 @@ Please read the `Nextstrain Github Contributing Guide <https://github.com/nextst
 
    Nextstrain Github Contributing Guide <https://github.com/nextstrain/.github/blob/master/CONTRIBUTING.md>
    documentation
-   Contribute to Nextstrain CLI <cli-develop>
-   Contribute to Augur <augur_develop>
-   Contribute to Auspice <auspice-develop>
+   Contribute to Nextstrain CLI <https://github.com/nextstrain/cli/tree/master/doc/development.md#readme>
+   Contribute to Augur <https://github.com/nextstrain/augur/tree/master/docs/contribute/DEV_DOCS.md#readme>
+   Contribute to Auspice <https://github.com/nextstrain/auspice/tree/master/DEV_DOCS.md#readme>

--- a/src/learn/interpret/interacting-with-nextstrain.md
+++ b/src/learn/interpret/interacting-with-nextstrain.md
@@ -7,7 +7,7 @@ Auspice is written in JavaScript and is the app that powers all the phylogenomic
 
 > This section is in need of work!
 If you are able to, we'd really appreciate contributions to improve the content here (or anywhere else in the docs).
-Please see [this page](../../guides/contribute/documentation) for how you can help.
+Please see [this page](../../guides/contribute/index) for how you can help.
 
 
 


### PR DESCRIPTION
### Description of proposed changes
See commit messages for details of the two changes and the [revised Contributing page](https://nextstrain--111.org.readthedocs.build/en/111/guides/contribute/index.html) in the preview build.

### Testing
- [x] Builds locally and views ok
- [x] CI passes
- [x] Redirects work as expected