### PR TITLE
Add commands to create intermediate conda environment with osx-64 emulation

### DIFF
--- a/src/install.rst
+++ b/src/install.rst
@@ -85,6 +85,21 @@ These instructions will install the Nextstrain CLI and tools to run and view you
 
             .. group-tab:: Native
 
+               .. warning::
+
+                  If using a newer Mac with an `Apple silicon chip <https://support.apple.com/en-us/HT211814>`_ (e.g. M1), first run these commands to ensure Conda creates the environment with ``osx-64`` emulation:
+
+                  .. code-block:: bash
+
+                     # Create a new environment using Intel packages called base_osx-64
+                     CONDA_SUBDIR=osx-64 conda create -n base_osx-64 python
+
+                     # Activate new Intel-based environment
+                     conda activate base_osx-64
+
+                     # Ensure future Conda commands in this environment use Intel packages too.
+                     conda config --env --set subdir osx-64
+
                1. Create a conda environment named ``nextstrain`` and install all the necessary software using mamba:
 
                   .. code-block:: bash


### PR DESCRIPTION
[_(preview)_](https://nextstrain--112.org.readthedocs.build/en/112/install.html)

### Description of proposed changes

This is for users on Apple Silicon. If emulation is not used, Conda will fail to find packages like `mafft` and `iqtree` since they are not available via `osx-arm64` or `noarch` (similar to https://github.com/nextstrain/cli/issues/14#issuecomment-1063583014 which is why the Native runtime is not an option on Windows without WSL). This is outside of our control, so the best recommendation is to use emulation which has worked well for me personally.

This makes the experience a bit ugly for M1 users. A better scenario would be if nextstrain/docker-base#35 is resolved and benchmarks prove that non-emulated Docker is faster or comparable to emulated Native. Then, this intermediate conda environment will not be the only installation path for M1 users that isn't slow like [emulated Docker is currently](https://github.com/nextstrain/docker-base/issues/35#issuecomment-1059480588).

### Related issue(s)

- Fixes #109

### Testing

Commands worked for myself and @alliblk.