### PR TITLE
Install SARS-CoV-2 workflow dependencies in Native runtime

### DIFF
--- a/src/install.rst
+++ b/src/install.rst
@@ -106,7 +106,7 @@ These instructions will install the Nextstrain CLI and tools to run and view you
 
                      mamba create -n nextstrain \
                        -c conda-forge -c bioconda \
-                       nextstrain-cli augur auspice nextalign snakemake git \
+                       nextstrain-cli augur auspice nextalign nextclade snakemake git epiweeks pangolin pangolearn \
                        --yes
 
                2. Activate the conda environment:
@@ -227,7 +227,7 @@ These instructions will install the Nextstrain CLI and tools to run and view you
 
                      mamba create -n nextstrain \
                        -c conda-forge -c bioconda \
-                       nextstrain-cli augur auspice nextalign snakemake git \
+                       nextstrain-cli augur auspice nextalign nextclade snakemake git epiweeks pangolin pangolearn \
                        --yes
 
                2. Activate the conda environment:
@@ -313,7 +313,7 @@ These instructions will install the Nextstrain CLI and tools to run and view you
 
                      mamba create -n nextstrain \
                        -c conda-forge -c bioconda \
-                       nextstrain-cli augur auspice nextalign snakemake git \
+                       nextstrain-cli augur auspice nextalign nextclade snakemake git epiweeks pangolin pangolearn \
                        --yes
 
                2. Activate the conda environment:


### PR DESCRIPTION
[_preview_](https://nextstrain--115.org.readthedocs.build/en/115/install.html)

### Description of proposed changes

The Nextstrain Docker image used by the Docker runtime comes with many
other software tools, so that the runtime can work with all core
pathogen workflows. In contrast, the current Native runtime installs a
"bare minimum" set of software, requiring individual workflows to
specify additional installation commands just for the Native runtime.
This commit effectively syncs the two runtimes to provide the same
tools.

In the long term, it would be best to abandon this approach of
supporting *n* pathogen workflows by a single setup (for both Docker and
Native runtime). While this might seem like taking a step backwards by
putting more potentially unused tools in the Native runtime, the
difference of available tools between Docker/Native currently causes
confusion for users and unnecessary instructions specific to the Native
runtime for each pathogen workflow.

### Related issue(s)

- Fixes #96
- Closes #116

### Testing

_N/A_

### TODO

- [x] create sibling PR in ncov repo to remove note on installing additional tools for Native runtime: nextstrain/ncov#967