### PR TITLE
Add note to look for other specific installation steps

### DIFF
--- a/src/install.rst
+++ b/src/install.rst
@@ -336,7 +336,7 @@ These instructions will install the Nextstrain CLI and tools to run and view you
 
 Optionally, :doc:`configure AWS Batch <cli:aws-batch>` if you'd like to run ``nextstrain build`` on AWS.
 
-Next, try :doc:`tutorials/running-a-workflow`.
+Next, try :doc:`tutorials/running-a-workflow`. Or, if you want to run a particular pathogen workflow, please check specific docs for additional installation steps (e.g. :doc:`setup steps for SARS-CoV-2 workflow <ncov:tutorial/setup>`).
 
 .. note::
 


### PR DESCRIPTION
### Description of proposed changes

Users may run through this generic Nextstrain installation and skip over
workflow-specific setup guides, which are necessary for installing
workflow-specific software requirements (e.g. pangolin for SARS-CoV-2)
that are not included in the generic installation steps.

This change adds a note and example link to SARS-CoV-2 setup steps given
the currently high usage of the SARS-CoV-2 workflow.

Note that this only impacts the Native environment.

### Related issue(s)

- Fixes #96
- Closes #115

### Testing

_N/A_