### PR TITLE
Install more Python deps with Pip instead of Conda, pin docutils<0.18

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,12 +4,12 @@ channels:
 dependencies:
   - graphviz
   - make
-  - recommonmark
-  - requests
-  - sphinx
   - pip
   - pip:
     - nextstrain-sphinx-theme>=2020.2
+    - recommonmark
+    - requests
+    - sphinx
     - sphinx-markdown-tables
     - sphinx-argparse
     - sphinx-tabs

--- a/environment.yml
+++ b/environment.yml
@@ -7,6 +7,7 @@ dependencies:
   - pip
   - pip:
     - nextstrain-sphinx-theme>=2020.2
+    - docutils<0.18
     - recommonmark
     - requests
     - sphinx


### PR DESCRIPTION
This is already done in nextstrain/ncov#975 and the same issues with the docs build are showing here (see failure on ed237c0cfc0e35f16640a23233c67376832b5aad).

Noting that the move from Conda -> Pip may not be necessary, but it should improve dependency resolution by not splitting the dependencies between Conda and Pip. Also keeping the `graphviz` Conda dependency since [`graphviz` on PyPI](https://pypi.org/project/graphviz/) is not the same.