### PR TITLE
Replace sphinx_copybutton with nextstrain.sphinx.theme

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ dependencies:
   - make
   - pip
   - pip:
-    - nextstrain-sphinx-theme>=2020.2
+    - nextstrain-sphinx-theme>=2022.5
     - docutils<0.18
     - recommonmark
     - requests

--- a/src/conf.py
+++ b/src/conf.py
@@ -40,7 +40,7 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx_tabs.tabs',
     'sphinx.ext.graphviz',
-    'sphinx_copybutton',
+    'nextstrain.sphinx.theme',
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
## Description of proposed changes

The new extension already has sphinx_copybutton pre-installed and configured.

## Related issue(s)

https://github.com/nextstrain/sphinx-theme/issues/30

## Testing

- [ ] copy button works on RTD preview build