### PR TITLE
Use standalone installation of Nextstrain CLI for Docker runtimes

### DIFF
--- a/src/install.rst
+++ b/src/install.rst
@@ -271,21 +271,37 @@ Update an existing installation
 Troubleshoot a broken installation
 ==================================
 
-If Conda fails to install or update Nextstrain using the commands above, it's possible that Conda itself is out-of-date or that Conda cannot figure out how to resolve the environment's dependencies.
-Try the following approaches, to fix these broken installations.
+.. tabs::
 
-Remove your environment and start from scratch
-----------------------------------------------
+   .. group-tab:: Docker
 
-Starting from scratch often fixes problems with Conda environments.
-To start over with a new Nextstrain environment, delete your current environment.
+      The Docker runtime requires that the Docker service is running on your computer behind the scenes.
+      If you see a message like::
 
-.. code-block:: bash
+         Cannot connect to the Docker daemon at […]. Is the docker daemon running?
 
-    conda activate base
-    conda env remove -n nextstrain
+      Then it is likely that the Docker service is not running.
+      On macOS and Windows, try quitting Docker Desktop (if it's open) and restarting it.
+      On Linux, try running ``sudo systemctl restart docker``.
 
-Then, repeat the installation instructions above, starting with the update of Conda itself.
+      Running ``nextstrain check-setup`` will also report potential issues.
+      Make sure there are no errors or warnings reported for the Docker runtime.
+
+
+   .. group-tab:: Native
+
+      If Conda fails to install or update Nextstrain using the commands above, it's possible that Conda itself is out-of-date or that Conda cannot figure out how to resolve the environment's dependencies.
+      Starting from scratch often fixes problems with Conda environments.
+      To start over with a new Nextstrain environment, delete your current environment.
+
+      .. code-block:: bash
+
+          conda activate base
+          conda env remove -n nextstrain
+
+      Then, repeat the installation instructions above, starting with the update of Conda itself.
+
+If you the above isn't sufficient and you need more help troubleshooting, please post to our `discussion forum <https://discussion.nextstrain.org/c/help-and-getting-started/6>`__ where members of the community and the Nextstrain team can help out.
 
 Alternate installation methods
 ==============================

--- a/src/install.rst
+++ b/src/install.rst
@@ -6,342 +6,267 @@ Installing Nextstrain
 
     Before installing, we recommend you read about the :doc:`parts of Nextstrain </learn/parts>`.
 
-The following instructions describe how to install Nextstrain's software tools, including:
+The following instructions describe how to install the full suite of Nextstrain's software tools, including:
 
-  * Augur: a bioinformatics toolkit for the analysis of pathogen genomes
-  * Auspice: a tool for interactive visualization of pathogen evolution
-  * Nextstrain CLI: tools for management of analysis workflows and environments
+  * Augur, for bioinformatic analysis of pathogen genomes
+  * Auspice, for interactive visualization of pathogen evolution
+  * Nextstrain CLI, for management of analysis workflows and environments
 
-.. note::
+When completed, you'll be ready to run Nextstrain :term:`workflows <workflow>`.
 
-    If you want to :doc:`contribute to the development of Nextstrain </guides/contribute/index>` or if you prefer to manage your own custom environment (e.g., a Conda environment, Docker image, environment modules on a cluster, etc.), see the individual installation documentation for :doc:`Nextstrain CLI <cli:installation>`, :doc:`Augur <augur:installation/installation>`, and :doc:`Auspice <auspice:introduction/install>`.
-
-.. contents:: Table of Contents
-   :local:
-   :depth: 1
-
-
-Background
-==========
-
-`Conda <https://docs.conda.io/en/latest/>`_ is a package and environment management system that allows you to install Python and other software into controlled environments without disrupting other software you have installed (e.g., on your computer, your shared cluster, etc.).
-Conda provides an appropriate version of Python required by all approaches to installing Nextstrain tools. Miniconda is the minimal installation of the command-line interface to Conda.
-
-`Mamba <https://github.com/mamba-org/mamba>`_ is a drop-in replacement for most ``conda`` functionality that implements a faster dependency solving algorithm in C++ and multithreaded downloads.
-As a result, Mamba can install Conda packages much faster and more accurately than the original Conda installer.
-
-`Docker <https://docker.com/>`_ is a container system freely-available for all platforms.
-When you use Docker to run Nextstrain components, you don’t need to manage any other Nextstrain software dependencies as validated versions are already bundled into `a container image by the Nextstrain team <https://github.com/nextstrain/docker-base/>`_.
-
-Installation Steps
+Installation steps
 ==================
 
-These instructions will install the Nextstrain CLI and tools to run and view your own Nextstrain analyses. Configuration options vary by operating system.
+Steps vary by runtime option (Docker, native) and operating system (macOS, Windows, WSL on Windows, Linux).
+For help choosing, refer to our :doc:`/reference/faq`, such as:
+
+  * :ref:`what-are-docker-conda-mamba-wsl-etc`
+  * :ref:`choosing-a-runtime`
+  * :ref:`when-to-use-wsl`
+
+First, install a Nextstrain runtime.
 
 .. tabs::
 
-   .. group-tab:: macOS
+   .. group-tab:: Docker
 
-      .. note::
+      .. tabs::
 
-         If you are an experienced user, you can replace ``conda`` with ``pip`` but :doc:`note the extra installation steps for Augur <augur:installation/installation>` and :doc:`install Auspice via npm <auspice:introduction/install>`.
+         .. group-tab:: macOS
 
-      1. Install Miniconda:
+            .. warning::
 
-         .. The installer link is taken from https://docs.conda.io/en/latest/miniconda.html.
+               If using a newer Mac with an `Apple silicon chip <https://support.apple.com/en-us/HT211814>`_ (e.g. M1), the **native** runtime is recommended due to slowness with the Docker runtime. `We are considering ways to improve this <https://github.com/nextstrain/docker-base/issues/35>`_.
 
-         a. `Download the installer <https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.pkg>`_.
+            1. `Install Docker Desktop using the official guide <https://docs.docker.com/desktop/install/mac-install/>`_.
+            2. Install the Nextstrain CLI:
 
-            .. note::
+               .. code-block:: bash
 
-                  This is the Intel x86 64-bit installer, :ref:`which we recommend even for Mac computers with Apple silicon (e.g. M1) <why-intel-miniconda-installer-on-apple-silicon>`.
+                  curl -fsSL --proto '=https' https://nextstrain.org/cli/installer/mac | bash
 
-         b. Open the downloaded file and follow through installation prompts.
 
-      2. Open a terminal window.
-      3. Install Mamba on the ``base`` Conda environment:
+         .. group-tab:: Windows
 
-         .. code-block:: bash
+            1. `Install Windows Subsystem for Linux (WSL) 2 <https://docs.microsoft.com/en-us/windows/wsl/install>`_.
 
-            conda install -n base -c conda-forge mamba --yes
-            conda activate base
+               .. note:: You may have to restart your machine when configuring WSL.
 
-      4. Install the Nextstrain components. There are two options:
+            2. `Install Docker Desktop with WSL 2 backend <https://docs.docker.com/desktop/windows/wsl/>`_.
+            3. Open a PowerShell prompt (not a WSL prompt) as your own user (not as an administrator).
+            4. Install the Nextstrain CLI.
 
-         .. tabs::
+               .. code-block:: powershell
 
-            .. group-tab:: Docker (recommended)
+                  Invoke-RestMethod https://nextstrain.org/cli/installer/windows | Invoke-Expression
 
-               .. warning::
 
-                  If using a newer Mac with an `Apple silicon chip <https://support.apple.com/en-us/HT211814>`_ (e.g. M1), **Native** installation is recommended due to slowness with the Docker installation. `We are considering ways to improve this <https://github.com/nextstrain/docker-base/issues/35>`_.
+         .. group-tab:: WSL on Windows
 
-               1. `Install Docker Desktop using the official guide <https://docs.docker.com/desktop/install/mac-install/>`_.
-               2. Create a Conda environment named ``nextstrain``:
+            1. `Install Windows Subsystem for Linux (WSL) 2 <https://docs.microsoft.com/en-us/windows/wsl/install>`_.
 
-                  .. include:: snippets/conda-create-bash.rst
+               .. note:: You may have to restart your machine when configuring WSL.
 
-               3. Install the Nextstrain CLI:
+            2. `Install Docker Desktop with WSL 2 backend <https://docs.docker.com/desktop/windows/wsl/>`_.
 
-                  .. code-block:: bash
+               .. note:: Make sure to follow through the last step of enabling **WSL Integration**.
 
-                     mamba install --yes nextstrain-cli
+            3. Open a WSL terminal by running **wsl** from the Start menu.
+            4. Install the Nextstrain CLI:
 
-            .. group-tab:: Native
+               .. code-block:: bash
 
-               1. Create a Conda environment named ``nextstrain``:
+                  curl -fsSL --proto '=https' https://nextstrain.org/cli/installer/linux | bash
 
-                  .. include:: snippets/conda-create-bash.rst
 
-               2. Install all the necessary software:
+         .. group-tab:: Ubuntu Linux
 
-                  .. include:: snippets/conda-install-full-bash.rst
+            .. note:: Steps for other Linux distributions (Debian, CentOS, RHEL, etc.) will be similar, though specific commands may vary slightly.
 
-      5. Confirm that the installation worked.
+            1. Install Docker Engine using the standard Ubuntu package:
 
-         .. code-block:: bash
+               .. code-block:: bash
 
-            nextstrain check-setup --set-default
+                  sudo apt install docker.io
 
-         The final output from the last command should look like this, where ``<option>`` is the option chosen in the previous step:
+               .. note::
 
-         .. code-block:: none
+                  See `Docker's installation documentation <https://docs.docker.com/engine/install/ubuntu/>`__ for alternative installation methods.
 
-            Setting default environment to <option>.
+            2. Add your user to the `docker` group:
 
-   .. group-tab:: Windows
+               .. code-block:: bash
 
-      .. note::
+                  sudo gpasswd --add $USER docker
 
-         Due to installation constraints, there is no way to use the native Nextstrain components on Windows directly. Follow steps for **WSL on Windows** if the native environment is desired, or use the **Docker**-based steps instead.
+            3. Restart your machine.
+            4. Install the Nextstrain CLI:
 
-      1. `Install Windows Subsystem for Linux (WSL) 2 <https://docs.microsoft.com/en-us/windows/wsl/install>`_.
+               .. code-block:: bash
 
-         .. note:: You may have to restart your machine when configuring WSL.
+                  curl -fsSL --proto '=https' https://nextstrain.org/cli/installer/linux | bash
 
-      2. `Install Docker Desktop with WSL 2 backend <https://docs.docker.com/desktop/windows/wsl/>`_.
-      3. Install Miniconda:
 
-         a. Go to the `installation page <https://docs.conda.io/en/latest/miniconda.html>`_.
-         b. Scroll down to the **Latest Miniconda Installer Links** section and click the Windows platform link relevant to your machine.
-         c. Open the downloaded file and follow through installation prompts.
+   .. group-tab:: Native
 
-      4. Open an Anaconda PowerShell Prompt, which can be found in the Start menu. Note that you should not use the *administrator* prompt.
-      5. Install Mamba on the ``base`` Conda environment:
+      .. tabs::
 
-         .. code-block:: powershell
+         .. group-tab:: macOS
 
-            conda install -n base -c conda-forge mamba --yes
-            conda activate base
+            1. Install Miniconda:
 
-      6. Create a Conda environment named ``nextstrain``:
+               .. The installer link is taken from https://docs.conda.io/en/latest/miniconda.html.
 
-         .. include:: snippets/conda-create-powershell.rst
-
-      7. Install the Nextstrain CLI:
-
-         .. code-block:: powershell
-
-            mamba install --yes nextstrain-cli
-
-      8. Confirm that the installation worked.
-
-         .. code-block:: powershell
-
-            nextstrain check-setup --set-default
-
-         The final output from the last command should look like this:
-
-         .. code-block:: none
-
-            Setting default environment to docker.
-
-   .. group-tab:: WSL on Windows
-
-      .. note::
-
-         If you are an experienced user, you can replace ``conda`` with ``pip`` but :doc:`note the extra installation steps for Augur <augur:installation/installation>` and :doc:`install Auspice via npm <auspice:introduction/install>`.
-
-      1. `Install Windows Subsystem for Linux (WSL) 2 <https://docs.microsoft.com/en-us/windows/wsl/install>`_.
-
-         .. note:: You may have to restart your machine when configuring WSL.
-
-      2. Open a WSL terminal by running **wsl** from the Start menu.
-      3. Install Miniconda:
-
-         .. code-block:: bash
-
-            wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
-            bash Miniconda3-latest-Linux-x86_64.sh
-            # follow through installation prompts
-            rm Miniconda3-latest-Linux-x86_64.sh
-
-      4. Install Mamba on the ``base`` Conda environment:
-
-         .. code-block:: bash
-
-            conda install -n base -c conda-forge mamba --yes
-            conda activate base
-
-      5. Install the Nextstrain components. There are two options:
-
-         .. tabs::
-
-            .. group-tab:: Docker (recommended)
-
-               1. On Windows, `install Docker Desktop with WSL 2 backend <https://docs.docker.com/desktop/windows/wsl/>`_.
-
-                  .. note:: Make sure to follow through the last step of enabling **WSL Integration**.
-
-               2. Create a Conda environment named ``nextstrain``:
-
-                  .. include:: snippets/conda-create-bash.rst
-
-               3. Install the Nextstrain CLI:
-
-                  .. code-block:: bash
-
-                     mamba install --yes nextstrain-cli
-
-            .. group-tab:: Native
-
-               1. Create a Conda environment named ``nextstrain``:
-
-                  .. include:: snippets/conda-create-bash.rst
-
-               2. Install all the necessary software:
-
-                  .. include:: snippets/conda-install-full-bash.rst
-
-      6. Confirm that the installation worked.
-
-         .. code-block:: bash
-
-            nextstrain check-setup --set-default
-
-         The final output from the last command should look like this, where ``<option>`` is the option chosen in the previous step:
-
-         .. code-block:: none
-
-            Setting default environment to <option>.
-
-      .. hint::
-
-         By default, your Windows home directory will not be directly accessible under your WSL home directory. When run in a WSL prompt, the following command fixes that by creating a symlink to it in your WSL home directory. This allows you to use Windows-based text editors and Linux commands all on the same files.
-
-         .. code-block:: bash
-
-               ln -ws "$(wslpath "$(wslvar USERPROFILE)")" ~/windows_home
-
-         Optionally, you can customize the ``windows_home`` folder name or only link to a specific directory under your windows user (e.g. ``ln -ws "$(wslpath "$(wslvar USERPROFILE)")/Documents" ~/windows_documents``).
-
-         If the command does not work, you may have to first run ``sudo apt install wslu``.
-
-   .. group-tab:: Ubuntu Linux
-
-      .. note::
-
-         If you are an experienced user, you can replace ``conda`` with ``pip`` but :doc:`note the extra installation steps for Augur <augur:installation/installation>` and :doc:`install Auspice via npm <auspice:introduction/install>`.
-
-      1. Install Miniconda:
-
-         .. code-block:: bash
-
-            wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
-            bash Miniconda3-latest-Linux-x86_64.sh
-            # follow through installation prompts
-            rm Miniconda3-latest-Linux-x86_64.sh
-
-      2. Install Mamba on the ``base`` Conda environment:
-
-         .. code-block:: bash
-
-            conda install -n base -c conda-forge mamba --yes
-            conda activate base
-
-      3. Install the Nextstrain components. There are two options:
-
-         .. tabs::
-
-            .. group-tab:: Docker (recommended)
-
-               .. note:: Steps for other Linux distributions (Debian, CentOS, RHEL, etc.) will be similar, though specific commands may vary slightly.
-
-               1. Install Docker Engine using the standard Ubuntu package:
-
-                  .. code-block:: bash
-
-                     sudo apt install docker.io
+               a. `Download the installer <https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.pkg>`_.
 
                   .. note::
 
-                     See `Docker's installation documentation <https://docs.docker.com/engine/install/ubuntu/>`__ for alternative installation methods.
+                        This is the Intel x86 64-bit installer, :ref:`which we recommend even for Mac computers with Apple silicon (e.g. M1) <why-intel-miniconda-installer-on-apple-silicon>`.
 
-               2. Add your user to the `docker` group:
+               b. Open the downloaded file and follow through installation prompts.
 
-                  .. code-block:: bash
+            2. Open a terminal window.
+            3. Install Mamba on the ``base`` Conda environment:
 
-                     sudo gpasswd --add $USER docker
+               .. code-block:: bash
 
-               3. Restart your machine.
-               4. Create a Conda environment named ``nextstrain``:
+                  conda install -n base -c conda-forge mamba --yes
+                  conda activate base
 
-                  .. include:: snippets/conda-create-bash.rst
+            4. Create a Conda environment named ``nextstrain``:
 
-               5. Install the Nextstrain CLI:
+               .. include:: snippets/conda-create-bash.rst
 
-                  .. code-block:: bash
+            5. Install all the necessary software:
 
-                     mamba install --yes nextstrain-cli
+               .. include:: snippets/conda-install-full-bash.rst
 
-            .. group-tab:: Native
 
-               .. note:: Steps for other Linux distributions (Debian, CentOS, RHEL, etc.) should be identical or very similar.
+         .. group-tab:: Windows
 
-               1. Create a Conda environment named ``nextstrain``:
+            .. note::
 
-                  .. include:: snippets/conda-create-bash.rst
+               Due to installation constraints, there is no way to use the native runtime on Windows directly. Follow steps for **WSL on Windows** if the native runtime is desired, or use the **Docker**-based steps instead.
 
-               2. Install all the necessary software:
 
-                  .. include:: snippets/conda-install-full-bash.rst
+         .. group-tab:: WSL on Windows
 
-      4. Confirm that the installation worked.
+            1. `Install WSL 2 <https://docs.microsoft.com/en-us/windows/wsl/install>`_.
+            2. Open a WSL terminal by running **wsl** from the Start menu.
+            3. Install Miniconda:
 
-         .. code-block:: bash
+               .. code-block:: bash
 
-            nextstrain check-setup --set-default
+                  wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
+                  bash Miniconda3-latest-Linux-x86_64.sh
+                  # follow through installation prompts
+                  rm Miniconda3-latest-Linux-x86_64.sh
 
-         The final output from the last command should look like this, where ``<option>`` is the option chosen in the previous step:
+            3. Install Mamba on the ``base`` Conda environment:
 
-         .. code-block:: none
+               .. code-block:: bash
 
-            Setting default environment to <option>.
+                  conda install -n base -c conda-forge mamba --yes
+                  conda activate base
+
+            4. Create a Conda environment named ``nextstrain``:
+
+               .. include:: snippets/conda-create-bash.rst
+
+            5. Install all the necessary software:
+
+               .. include:: snippets/conda-install-full-bash.rst
+
+
+         .. group-tab:: Ubuntu Linux
+
+            .. note:: Steps for other Linux distributions (Debian, CentOS, RHEL, etc.) should be identical or very similar.
+
+            1. Install Miniconda:
+
+               .. code-block:: bash
+
+                  wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
+                  bash Miniconda3-latest-Linux-x86_64.sh
+                  # follow through installation prompts
+                  rm Miniconda3-latest-Linux-x86_64.sh
+
+            2. Install Mamba on the ``base`` Conda environment:
+
+               .. code-block:: bash
+
+                  conda install -n base -c conda-forge mamba --yes
+                  conda activate base
+
+            3. Create a Conda environment named ``nextstrain``:
+
+               .. include:: snippets/conda-create-bash.rst
+
+            4. Install all the necessary software:
+
+               .. include:: snippets/conda-install-full-bash.rst
+
+
+Then, confirm that the installation worked.
+
+.. code-block:: bash
+
+  nextstrain check-setup --set-default
+
+The final output from the last command should look like this, where ``<runtime>`` is the runtime option (e.g. ``docker`` or ``native``) chosen in the first step:
+
+.. code-block:: none
+
+  Setting default environment to <runtime>.
 
 Optionally, :doc:`configure AWS Batch <cli:aws-batch>` if you'd like to run ``nextstrain build`` on AWS.
 
 Next, try :doc:`tutorials/running-a-workflow`.
 
-.. note::
+.. admonition:: For native runtime installs
+   :class: hint
 
    Whenever you open a new terminal window to work on a Nextstrain analysis, remember to activate the Conda environment with ``conda activate nextstrain``.
+
+.. admonition:: For WSL on Windows installs
+   :class: hint
+
+   By default, your Windows home directory will not be directly accessible under your WSL home directory. When run in a WSL prompt, the following command fixes that by creating a symlink to it in your WSL home directory. This allows you to use Windows-based text editors and Linux commands all on the same files.
+
+   .. code-block:: bash
+
+         ln -ws "$(wslpath "$(wslvar USERPROFILE)")" ~/windows_home
+
+   Optionally, you can customize the ``windows_home`` folder name or only link to a specific directory under your windows user (e.g. ``ln -ws "$(wslpath "$(wslvar USERPROFILE)")/Documents" ~/windows_documents``).
+
+   If the command does not work, you may have to first run ``sudo apt install wslu``.
 
 Update an existing installation
 ================================
 
-Update the ``nextstrain`` Conda environment.
+.. tabs::
 
-.. code-block:: bash
+   .. group-tab:: Docker
 
-   mamba update -n base conda mamba
-   conda activate nextstrain
-   mamba update --all
+      Download the latest image with the Nextstrain CLI.
 
-[Docker] Download the latest image with the Nextstrain CLI.
+      .. code-block:: bash
 
-.. code-block:: bash
+         nextstrain update
 
-   nextstrain update
+      If the output notes that an update of the Nextstrain CLI itself is available, run the suggested command (after optionally reviewing the release notes).
+
+
+   .. group-tab:: Native
+
+      Update the ``nextstrain`` Conda environment.
+
+      .. code-block:: bash
+
+         mamba update -n base conda mamba
+         conda activate nextstrain
+         mamba update --all
+
 
 Troubleshoot a broken installation
 ==================================
@@ -361,6 +286,11 @@ To start over with a new Nextstrain environment, delete your current environment
     conda env remove -n nextstrain
 
 Then, repeat the installation instructions above, starting with the update of Conda itself.
+
+Alternate installation methods
+==============================
+
+If you want to :doc:`contribute to the development of Nextstrain </guides/contribute/index>` or if you prefer to manage your own custom environment (e.g., a Conda environment, Docker image, environment modules on a cluster, etc.), see the individual installation documentation for :doc:`Nextstrain CLI <cli:installation>`, :doc:`Augur <augur:installation/installation>`, and :doc:`Auspice <auspice:introduction/install>`.
 
 Next steps
 ==========

--- a/src/install.rst
+++ b/src/install.rst
@@ -63,7 +63,7 @@ First, install a Nextstrain runtime.
 
          .. group-tab:: WSL on Windows
 
-            1. `Install Windows Subsystem for Linux (WSL) 2 <https://docs.microsoft.com/en-us/windows/wsl/install>`_.
+            1. `Install Windows Subsystem for Linux (WSL) 2`_.
 
                .. note:: You may have to restart your machine when configuring WSL.
 
@@ -151,7 +151,7 @@ First, install a Nextstrain runtime.
 
          .. group-tab:: WSL on Windows
 
-            1. `Install WSL 2 <https://docs.microsoft.com/en-us/windows/wsl/install>`_.
+            1. `Install Windows Subsystem for Linux (WSL) 2`_.
             2. Open a WSL terminal by running **wsl** from the Start menu.
             3. Install Miniconda:
 

--- a/src/install.rst
+++ b/src/install.rst
@@ -52,7 +52,7 @@ First, install a Nextstrain runtime.
 
                .. note:: You may have to restart your machine when configuring WSL.
 
-            2. `Install Docker Desktop with WSL 2 backend <https://docs.docker.com/desktop/windows/wsl/>`_.
+            2. `Install Docker Desktop <https://docs.docker.com/desktop/install/windows-install/>`_ with the `WSL 2 backend <https://docs.docker.com/desktop/windows/wsl/>`_.
             3. Open a PowerShell prompt (not a WSL prompt) as your own user (not as an administrator).
             4. Install the Nextstrain CLI.
 
@@ -67,7 +67,7 @@ First, install a Nextstrain runtime.
 
                .. note:: You may have to restart your machine when configuring WSL.
 
-            2. `Install Docker Desktop with WSL 2 backend <https://docs.docker.com/desktop/windows/wsl/>`_.
+            2. `Install Docker Desktop`_ with the `WSL 2 backend`_.
 
                .. note:: Make sure to follow through the last step of enabling **WSL Integration**.
 

--- a/src/install.rst
+++ b/src/install.rst
@@ -292,6 +292,34 @@ Alternate installation methods
 
 If you want to :doc:`contribute to the development of Nextstrain </guides/contribute/index>` or if you prefer to manage your own custom environment (e.g., a Conda environment, Docker image, environment modules on a cluster, etc.), see the individual installation documentation for :doc:`Nextstrain CLI <cli:installation>`, :doc:`Augur <augur:installation/installation>`, and :doc:`Auspice <auspice:introduction/install>`.
 
+Uninstall
+=========
+
+We do not have an automated uninstall process currently.
+Instead, follow these manual steps:
+
+.. tabs::
+
+   .. group-tab:: Docker
+
+      1. If the directory :file:`~/.nextstrain` exists, remove it.
+      2. Remove all ``nextstrain/…`` Docker images::
+
+            docker image rm $(docker image ls -q "nextstrain/*")
+
+      3. Optionally, uninstall Docker if only used for Nextstrain.
+      4. On Windows, optionally, uninstall WSL if only used for Nextstrain.
+
+   .. group-tab:: Native
+
+      1. If the directory :file:`~/.nextstrain` exists, remove it.
+      2. Remove the ``nextstrain`` Conda environment::
+
+            conda env remove -n nextstrain
+
+      3. Optionally, uninstall Conda if only used for Nextstrain.
+      4. On Windows, optionally, uninstall WSL if only used for Nextstrain.
+
 Next steps
 ==========
 

--- a/src/install.rst
+++ b/src/install.rst
@@ -78,6 +78,8 @@ First, install a Nextstrain runtime.
 
                   curl -fsSL --proto '=https' https://nextstrain.org/cli/installer/linux | bash
 
+            .. include:: snippets/wsl-home-dir.rst
+
 
          .. group-tab:: Ubuntu Linux
 
@@ -177,6 +179,8 @@ First, install a Nextstrain runtime.
 
                .. include:: snippets/conda-install-full-bash.rst
 
+            .. include:: snippets/wsl-home-dir.rst
+
 
          .. group-tab:: Ubuntu Linux
 
@@ -206,6 +210,12 @@ First, install a Nextstrain runtime.
 
                .. include:: snippets/conda-install-full-bash.rst
 
+      .. admonition:: For native runtime installs
+         :class: hint
+
+         Whenever you open a new terminal window to work on a Nextstrain analysis, remember to activate the Conda environment with ``conda activate nextstrain``.
+
+
 
 Then, confirm that the installation worked.
 
@@ -223,23 +233,6 @@ Optionally, :doc:`configure AWS Batch <cli:aws-batch>` if you'd like to run ``ne
 
 Next, try :doc:`tutorials/running-a-workflow`.
 
-.. admonition:: For native runtime installs
-   :class: hint
-
-   Whenever you open a new terminal window to work on a Nextstrain analysis, remember to activate the Conda environment with ``conda activate nextstrain``.
-
-.. admonition:: For WSL on Windows installs
-   :class: hint
-
-   By default, your Windows home directory will not be directly accessible under your WSL home directory. When run in a WSL prompt, the following command fixes that by creating a symlink to it in your WSL home directory. This allows you to use Windows-based text editors and Linux commands all on the same files.
-
-   .. code-block:: bash
-
-         ln -ws "$(wslpath "$(wslvar USERPROFILE)")" ~/windows_home
-
-   Optionally, you can customize the ``windows_home`` folder name or only link to a specific directory under your windows user (e.g. ``ln -ws "$(wslpath "$(wslvar USERPROFILE)")/Documents" ~/windows_documents``).
-
-   If the command does not work, you may have to first run ``sudo apt install wslu``.
 
 Update an existing installation
 ================================

--- a/src/install.rst
+++ b/src/install.rst
@@ -45,6 +45,8 @@ First, install a Nextstrain runtime.
 
                   curl -fsSL --proto '=https' https://nextstrain.org/cli/installer/mac | bash
 
+            3. Follow the installer's final instructions to setup your shell config.
+
 
          .. group-tab:: Windows
 
@@ -78,6 +80,8 @@ First, install a Nextstrain runtime.
 
                   curl -fsSL --proto '=https' https://nextstrain.org/cli/installer/linux | bash
 
+            5. Follow the installer's final instructions to setup your shell config.
+
             .. include:: snippets/wsl-home-dir.rst
 
 
@@ -107,6 +111,8 @@ First, install a Nextstrain runtime.
                .. code-block:: bash
 
                   curl -fsSL --proto '=https' https://nextstrain.org/cli/installer/linux | bash
+
+            5. Follow the installer's final instructions to setup your shell config.
 
 
    .. group-tab:: Native

--- a/src/reference/faq.rst
+++ b/src/reference/faq.rst
@@ -9,6 +9,62 @@ Installation
 
 There are many ways to install Nextstrain, and we aim to simplify the installation guide so it is easy to follow along. Here, you will find answers to some common questions about the installation process.
 
+
+.. _what-are-docker-conda-mamba-wsl-etc:
+
+What are Docker, Conda, Mamba, WSL, etc.?
+-----------------------------------------
+
+`Docker <https://docker.com/>`_ is a container system available for all platforms.
+When you use Docker to run Nextstrain components, you don’t need to manage any other Nextstrain software dependencies as validated versions are already bundled into `a container image by the Nextstrain team <https://github.com/nextstrain/docker-base/>`_.
+
+`Conda <https://docs.conda.io/en/latest/>`_ is a package and environment management system that allows you to install Python and other software into controlled environments without disrupting other software you have installed (e.g., on your computer, your shared cluster, etc.).
+Miniconda is the minimal installation of the ``conda`` command, the command-line interface to Conda.
+
+`Mamba <https://github.com/mamba-org/mamba>`_ is a drop-in replacement for most ``conda`` functionality that provides faster installation times, especially for complex environments like the one Nextstrain requires.
+
+`WSL <https://docs.microsoft.com/en-us/windows/wsl/about>`__ is Windows Subsystem for Linux, a full Linux environment integrated into Windows without the need for awkward virtual machines.
+Nextstrain's installation guide works with WSL 2 but not WSL 1.
+
+
+.. _choosing-a-runtime:
+
+Should I choose the Docker or native runtime?
+---------------------------------------------
+
+The two runtimes provide the same experience running Nextstrain workflows with ``nextstrain build`` (and most other ``nextstrain`` commands) but vary in installation and update methods and predictability/stability over time.
+
+There's not one right answer for everyone or every situation.
+That's why we provide both options (and will potentially provide more in the future).
+The Nextstrain team uses both runtimes extensively.
+
+Your preference is perhaps the best reason to choose one vs. the other.
+
+   - If you have a preference for containers, then choose the Docker runtime.
+   - If you have a preference for Conda, then choose the native runtime.
+   - If you don't have a preference, choose the one you have the most past experience with.
+   - If you have neither preference nor experience, we recommend choosing the Docker runtime because it has less to manage and is more predictable/stable over time.
+
+You can also install and use both runtimes on the same computer, if you want to use them contextually.
+For example, ``nextstrain`` commands let you select a different runtime than your default using command-line options (``--docker`` or ``--native``).
+
+If you pick one and later realize you want to switch, you can go back and install the other and make it your default.
+
+
+.. _when-to-use-wsl:
+
+When should I use (or not use) WSL on Windows?
+----------------------------------------------
+
+All of our Windows installation guides actually require WSL; the difference between them is in the interface you ultimately use for Nextstrain.
+This makes the choice mostly hinge on if you prefer a GNU/Linux `Bash shell <https://www.gnu.org/software/bash/manual/bash.html#What-is-Bash_003f>`__ interface or a Windows `PowerShell <https://docs.microsoft.com/en-us/powershell/scripting/discover-powershell>`__ interface for your command-line work.
+If you don't have a preference (e.g. perhaps you're new to both), we suggest choosing the Bash shell.
+Learning Bash will likely be useful in other work, as it is very widely used in bioinformatics and computing at large.
+
+The other deciding factor is if you're unable to install Docker (e.g. for adminstrative or organizational reasons), then you'll need to use the **Native** runtime with **WSL on Windows**.
+The native runtime is not available without WSL.
+
+
 .. _why-intel-miniconda-installer-on-apple-silicon:
 
 Why recommend the Intel Miniconda installer for Mac computers with Apple silicon (e.g. M1)?

--- a/src/snippets/wsl-home-dir.rst
+++ b/src/snippets/wsl-home-dir.rst
@@ -1,0 +1,12 @@
+.. admonition:: For WSL on Windows installs
+   :class: hint
+
+   By default, your Windows home directory will not be directly accessible under your WSL home directory. When run in a WSL prompt, the following command fixes that by creating a symlink to it in your WSL home directory. This allows you to use Windows-based text editors and Linux commands all on the same files.
+
+   .. code-block:: bash
+
+         ln -ws "$(wslpath "$(wslvar USERPROFILE)")" ~/windows_home
+
+   Optionally, you can customize the ``windows_home`` folder name or only link to a specific directory under your windows user (e.g. ``ln -ws "$(wslpath "$(wslvar USERPROFILE)")/Documents" ~/windows_documents``).
+
+   If the command does not work, you may have to first run ``sudo apt install wslu``.

--- a/src/tutorials/creating-a-bacterial-pathogen-workflow.rst
+++ b/src/tutorials/creating-a-bacterial-pathogen-workflow.rst
@@ -17,13 +17,7 @@ Prerequisites
 Setup
 =====
 
-1. Activate the ``nextstrain`` conda environment.
-
-   .. code-block:: bash
-
-      conda activate nextstrain
-
-2. Download the example :term:`workflow repository` and enter the new directory.
+1. Download the example :term:`workflow repository` and enter the new directory.
 
    .. code-block:: bash
 

--- a/src/tutorials/creating-a-workflow.rst
+++ b/src/tutorials/creating-a-workflow.rst
@@ -21,25 +21,19 @@ Prerequisites
 Setup
 =====
 
-1. Activate the ``nextstrain`` conda environment.
-
-   .. code-block:: bash
-
-      conda activate nextstrain
-
-2. Change directory to the Zika :term:`workflow repository` downloaded in the previous tutorial.
+1. Change directory to the Zika :term:`workflow repository` downloaded in the previous tutorial.
 
    .. code-block:: bash
 
       cd zika-tutorial
 
-3. Create a folder for results.
+2. Create a folder for results.
 
    .. code-block:: bash
 
       mkdir -p results/
 
-4. Additionally, if you installed Nextstrain with the :term:`Docker runtime<runtime>`, start Docker and enter the runtime.
+3. Additionally, if you installed Nextstrain with the :term:`Docker runtime<runtime>`, start Docker and enter the runtime.
 
    .. code-block:: bash
 

--- a/src/tutorials/running-a-workflow.rst
+++ b/src/tutorials/running-a-workflow.rst
@@ -17,15 +17,6 @@ Prerequisites
 
 1. :doc:`Install Nextstrain </install>`. These instructions will install all of the software you need to complete this tutorial and others.
 
-Setup
-=====
-
-Activate the ``nextstrain`` conda environment.
-
-.. code-block::
-
-    conda activate nextstrain
-
 Download the example Zika workflow repository
 =============================================
 


### PR DESCRIPTION
[Preview](https://nextstrain--123.org.readthedocs.build/en/123/install.html)

---

Reorganizes the tabs to be runtime first then OS (instead of OS then runtime) as I think this makes more sense now that the initial steps of installing and setting up a base Conda env aren't shared.  It also means we don't have multiple levels of ordered lists (steps), which is a nice simplification.
The goal is simplify this installation path quite a bit by avoiding the Python bootstrapping issue.

Reorganizes the tabs to be runtime first then OS (instead of OS then runtime) as I think this makes more sense now that the initial steps of installing and setting up a base Conda env aren't shared.  It also means we don't have multiple levels of ordered lists (steps), which is a nice simplification.

Moves verbose explanatory information out into the FAQ and adds more explanation about how to make various choices.

Moves the hint for WSL on Windows installs next to the hint for Native installs at the bottom.  This avoids duplicating it in both of the WSL on Windows tabs and it taking up a lot of visual space in those tabs.

Related-to: <https://github.com/nextstrain/nextstrain.org/pull/582>
Related-to: <https://github.com/nextstrain/cli/pull/217>

## Todo

- [x] Actual install commands and nextstrain.org endpoints serving the installer
- [x] ~Produce MSIs for Windows~ Nope, PowerShell program works just fine. Maybe we'll do MSIs later.
- [x] Document how to make various choices (runtime, WSL or not)
- [x] Figure out best approach for `PATH` handling on Unix (e.g. auto-add to shell config? suggest sourcing a provided file for your shell?)
- [x] Release new Nextstrain CLI with `init-shell` for new standalone installers to use

## Related

- https://github.com/nextstrain/cli/pull/217
- https://github.com/nextstrain/nextstrain.org/pull/582
