### PR TITLE
Add instructions for existing Conda installations

### DIFF
--- a/src/install.rst
+++ b/src/install.rst
@@ -46,7 +46,7 @@ These instructions will install the Nextstrain CLI and tools to run and view you
 
          If you are an experienced user, you can replace ``conda`` with ``pip`` but :doc:`note the extra installation steps for Augur <augur:installation/installation>` and :doc:`install Auspice via npm <auspice:introduction/install>`.
 
-      1. Install Miniconda:
+      1. Install Miniconda if you don't have ``conda`` yet:
 
          .. The installer link is taken from https://docs.conda.io/en/latest/miniconda.html.
 
@@ -89,6 +89,10 @@ These instructions will install the Nextstrain CLI and tools to run and view you
 
             .. group-tab:: Native
 
+               .. warning::
+
+                  If you already had Conda installed prior to following these steps **and** are using a newer Mac with an `Apple silicon chip <https://support.apple.com/en-us/HT211814>`_ (e.g. M1), please :ref:`read this FAQ section to see if you should run an extra step before proceeding <check-existing-conda-installation>`.
+
                1. Create a Conda environment named ``nextstrain``:
 
                   .. include:: snippets/conda-create-bash.rst
@@ -120,7 +124,7 @@ These instructions will install the Nextstrain CLI and tools to run and view you
          .. note:: You may have to restart your machine when configuring WSL.
 
       2. `Install Docker Desktop with WSL 2 backend <https://docs.docker.com/desktop/windows/wsl/>`_.
-      3. Install Miniconda:
+      3. Install Miniconda if you don't have ``conda`` yet:
 
          a. Go to the `installation page <https://docs.conda.io/en/latest/miniconda.html>`_.
          b. Scroll down to the **Latest Miniconda Installer Links** section and click the Windows platform link relevant to your machine.
@@ -167,7 +171,7 @@ These instructions will install the Nextstrain CLI and tools to run and view you
          .. note:: You may have to restart your machine when configuring WSL.
 
       2. Open a WSL terminal by running **wsl** from the Start menu.
-      3. Install Miniconda:
+      3. Install Miniconda if you don't have ``conda`` yet:
 
          .. code-block:: bash
 
@@ -231,7 +235,7 @@ These instructions will install the Nextstrain CLI and tools to run and view you
 
          If you are an experienced user, you can replace ``conda`` with ``pip`` but :doc:`note the extra installation steps for Augur <augur:installation/installation>` and :doc:`install Auspice via npm <auspice:introduction/install>`.
 
-      1. Install Miniconda:
+      1. Install Miniconda if you don't have ``conda`` yet:
 
          .. code-block:: bash
 

--- a/src/reference/faq.rst
+++ b/src/reference/faq.rst
@@ -20,7 +20,43 @@ Why recommend the Intel Miniconda installer for Mac computers with Apple silicon
 
 Apple silicon chips are great and efficient. However, many existing packages have not yet added support to run on these chips natively. An easy way to identify support on the `Bioconda packages page <https://anaconda.org/bioconda>`_ is to look for ``noarch`` or ``osx-arm64`` under the **Installers** section of a package. Without any of those, a package is not able to be installed natively on Apple silicon. This is the case for packages such as `MAFFT <https://anaconda.org/bioconda/mafft>`_ (a dependency of :term:`Augur`) and many other bioinformatics packages. For this reason, using an Apple silicon Miniconda installation for the average bioinformatics researcher can result in a difficult experience. To circumvent this, one may enable ``osx-64`` emulation using the ``subdir`` config on each Conda environment, but it is easier to install with emulation by default.
 
-For those who really want to use the ``arm64`` Miniconda installer, it is still possible to set up the ``nextstrain`` Conda environment by configuring it to run with emulation. Run this after setting up the empty Conda environment and before the ``mamba install`` command:
+.. _check-existing-conda-installation:
+
+Note for Apple silicon users with an existing Conda installation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Conda is a popular tool, and you may already have it installed. If you are using a Mac computer with Apple silicon, the type of Conda installation determines whether you should run an additional step in Nextstrain installation.
+
+1. Create and activate a new Conda environment with just Python installed:
+
+   .. code-block:: bash
+
+      mamba create -n tmp python --yes
+      conda activate tmp
+
+2. Check the type of Conda installation via Python:
+
+   .. code-block:: bash
+
+      python -c "import platform;print(platform.machine())"
+
+   The output should be one of the following:
+
+   - ``x86_64``: This means you have an Intel Conda installation. We recommend keeping this installation method and there is no extra step for Nextstrain installation.
+   - ``arm64``: This means you have an Apple silicon Conda installation. You can choose to keep this installation to retain existing Conda environments, or to re-install with the Intel installer (note that you will have to re-create any existing environments). If you choose to keep this installation, please follow directions in the next section to properly install Nextstrain.
+
+3. Remove the temporary Conda environment:
+
+   .. code-block:: bash
+
+      conda env remove -n tmp
+
+.. _install-nextstrain-on-apple-silicon-conda:
+
+Workaround for installing Nextstrain on an Apple silicon Conda installation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For those who really want to use an Apple silicon (``arm64``) Conda installation, it is still possible to set up the ``nextstrain`` Conda environment by configuring it to run with emulation. Run this after setting up the empty ``nextstrain`` environment and before the ``mamba install`` command:
 
 .. code-block:: bash
 


### PR DESCRIPTION
_[(preview)](https://nextstrain--126.org.readthedocs.build/en/126/install.html)_

### Description of proposed changes

It's likely that some users reading the installation docs will already
have Conda installed. The current docs do not take this into account.
Adding a path for these users, especially those using Apple silicon
computers which may complicate the installation process.

### Related issue(s)

- Closes #125

### Testing

- [ ] Get users to run through new docs?