### PR TITLE
Fix links to Auspice server overview page

### DIFF
--- a/src/guides/share/index.rst
+++ b/src/guides/share/index.rst
@@ -93,4 +93,4 @@ Custom Auspice servers
 Auspice can be run on your own server, including customizations to the appearance and functionality.
 This may be appropriate when you want or need full control over how the website is deployed and where the data is stored.
 
-See :doc:`auspice:server/index` for more information on how to set this up.
+See :doc:`auspice:server/overview` for more information on how to set this up.

--- a/src/learn/parts.rst
+++ b/src/learn/parts.rst
@@ -228,7 +228,7 @@ dataset.
 You can run :term:`Augur` and :term:`Auspice` on
 your own computer and use them independently or together with your own builds,
 our core builds, or others' group or community builds.  You can even install
-Auspice on :doc:`your own web server <auspice:server/index>` if you don't want
+Auspice on :doc:`your own web server <auspice:server/overview>` if you don't want
 to host your datasets via nextstrain.org.
 
 The :term:`Nextstrain CLI` ties


### PR DESCRIPTION
### Description of proposed changes

The page was moved in https://github.com/nextstrain/auspice/commit/20be0560a3d881466cb7945699e4c720a815d579.

### Related issue(s)

_N/A_

### Testing

- [x] Checks pass