### PR TITLE
install: Add instructions for the Conda runtime

### DIFF
--- a/src/install.rst
+++ b/src/install.rst
@@ -149,16 +149,25 @@ Then, install a Nextstrain runtime.
 
    .. group-tab:: Conda
 
-      .. note::
+      .. tabs::
 
-         Due to installation constraints, there is no way to use Nextstrain's Conda runtime on Windows directly. Starting from the beginning, follow steps for **WSL on Windows** if the Conda runtime is desired, or use the **Docker** runtime instead.
+         .. group-tab:: macOS
 
-      Set up the runtime:
+            .. include:: snippets/nextstrain-setup-conda.rst
 
-      .. code-block:: none
+         .. group-tab:: Windows
 
-         nextstrain setup --set-default conda
+            .. note::
 
+               Due to installation constraints, there is no way to use Nextstrain's Conda runtime on Windows directly. Starting from the beginning, follow steps for **WSL on Windows** if the Conda runtime is desired, or use the **Docker** runtime instead.
+
+         .. group-tab:: WSL on Windows
+
+            .. include:: snippets/nextstrain-setup-conda.rst
+
+         .. group-tab:: Ubuntu Linux
+
+            .. include:: snippets/nextstrain-setup-conda.rst
 
    .. group-tab:: Ambient
 

--- a/src/install.rst
+++ b/src/install.rst
@@ -17,7 +17,7 @@ When completed, you'll be ready to run Nextstrain :term:`workflows <workflow>`.
 Installation steps
 ==================
 
-Steps vary by runtime option (Docker, ambient) and operating system (macOS, Windows, WSL on Windows, Linux).
+Steps vary by runtime option (Docker, Conda, ambient) and operating system (macOS, Windows, WSL on Windows, Linux).
 For help choosing, refer to our :doc:`/reference/faq`, such as:
 
   * :ref:`what-are-docker-conda-mamba-wsl-etc`
@@ -25,216 +25,271 @@ For help choosing, refer to our :doc:`/reference/faq`, such as:
   * :ref:`what-happened-to-the-native-runtime`
   * :ref:`when-to-use-wsl`
 
-First, install a Nextstrain runtime.
+First, install Nextstrain CLI.
+
+.. tabs::
+
+   .. group-tab:: macOS
+
+      In a Terminal, run:
+
+      .. code-block:: bash
+
+         curl -fsSL --proto '=https' https://nextstrain.org/cli/installer/mac | bash
+
+      You can launch a Terminal by clicking the Launchpad icon in the Dock, typing ``terminal`` in the search field, and clicking Terminal.
+
+
+   .. group-tab:: Windows
+
+      In a PowerShell terminal, run:
+
+      .. code-block:: powershell
+
+         Invoke-RestMethod https://nextstrain.org/cli/installer/windows | Invoke-Expression
+
+      You can launch a PowerShell terminal by clicking the Start menu, typing ``powershell``, and pressing enter.
+      Make sure to choose the item that is **not** marked "(Adminstrator)".
+
+
+   .. group-tab:: WSL on Windows
+
+      `Install Windows Subsystem for Linux (WSL) 2 <https://docs.microsoft.com/en-us/windows/wsl/install>`_.
+      You may have to restart your machine when configuring WSL.
+
+      In a WSL terminal, run:
+
+      .. code-block:: bash
+
+         curl -fsSL --proto '=https' https://nextstrain.org/cli/installer/linux | bash
+
+      You can launch a WSL terminal by clicking the Start menu, typing ``wsl``, and pressing enter.
+
+
+   .. group-tab:: Ubuntu Linux
+
+      In a terminal, run:
+
+      .. code-block:: bash
+
+         curl -fsSL --proto '=https' https://nextstrain.org/cli/installer/linux | bash
+
+      You can launch a terminal by clicking the "Show applications" icon in the Dock, typing ``terminal`` in the search field, and clicking Terminal.
+
+
+Make sure to follow the installer's final instructions to setup your shell config.
+
+
+Then, install a Nextstrain runtime.
 
 .. tabs::
 
    .. group-tab:: Docker
 
-      .. tabs::
+      1. Install Docker on your computer.
 
-         .. group-tab:: macOS
+         .. tabs::
 
-            .. warning::
+            .. group-tab:: macOS
 
-               If using a newer Mac with an `Apple silicon chip <https://support.apple.com/en-us/HT211814>`_ (e.g. M1), the **ambient** runtime is recommended due to slowness with the Docker runtime. `We are considering ways to improve this <https://github.com/nextstrain/docker-base/issues/35>`_.
+               .. warning::
 
-            1. `Install Docker Desktop using the official guide <https://docs.docker.com/desktop/install/mac-install/>`_.
-            2. Install the Nextstrain CLI:
+                  If using a newer Mac with an `Apple silicon chip <https://support.apple.com/en-us/HT211814>`_ (e.g. M1), the **Conda** runtime is recommended due to slowness with the Docker runtime. `We are considering ways to improve this <https://github.com/nextstrain/docker-base/issues/35>`_.
 
-               .. code-block:: bash
-
-                  curl -fsSL --proto '=https' https://nextstrain.org/cli/installer/mac | bash
-
-            3. Follow the installer's final instructions to setup your shell config.
+               `Install Docker Desktop for macOS <https://docs.docker.com/desktop/install/mac-install/>`_.
 
 
-         .. group-tab:: Windows
+            .. group-tab:: Windows
 
-            1. `Install Windows Subsystem for Linux (WSL) 2 <https://docs.microsoft.com/en-us/windows/wsl/install>`_.
+               `Install Windows Subsystem for Linux (WSL) 2`_.
+               You may have to restart your machine when configuring WSL.
 
-               .. note:: You may have to restart your machine when configuring WSL.
-
-            2. `Install Docker Desktop <https://docs.docker.com/desktop/install/windows-install/>`_ with the `WSL 2 backend <https://docs.docker.com/desktop/windows/wsl/>`_.
-            3. Open a PowerShell prompt (not a WSL prompt) as your own user (not as an administrator).
-            4. Install the Nextstrain CLI.
-
-               .. code-block:: powershell
-
-                  Invoke-RestMethod https://nextstrain.org/cli/installer/windows | Invoke-Expression
+               `Install Docker Desktop for Windows <https://docs.docker.com/desktop/install/windows-install/>`_ with the `WSL 2 backend <https://docs.docker.com/desktop/windows/wsl/>`_.
 
 
-         .. group-tab:: WSL on Windows
+            .. group-tab:: WSL on Windows
 
-            1. `Install Windows Subsystem for Linux (WSL) 2`_.
-
-               .. note:: You may have to restart your machine when configuring WSL.
-
-            2. `Install Docker Desktop`_ with the `WSL 2 backend`_.
-
-               .. note:: Make sure to follow through the last step of enabling **WSL Integration**.
-
-            3. Open a WSL terminal by running **wsl** from the Start menu.
-            4. Install the Nextstrain CLI:
-
-               .. code-block:: bash
-
-                  curl -fsSL --proto '=https' https://nextstrain.org/cli/installer/linux | bash
-
-            5. Follow the installer's final instructions to setup your shell config.
-
-            .. include:: snippets/wsl-home-dir.rst
-
-
-         .. group-tab:: Ubuntu Linux
-
-            .. note:: Steps for other Linux distributions (Debian, CentOS, RHEL, etc.) will be similar, though specific commands may vary slightly.
-
-            1. Install Docker Engine using the standard Ubuntu package:
-
-               .. code-block:: bash
-
-                  sudo apt install docker.io
+               `Install Docker Desktop for Windows`_ with the `WSL 2 backend`_.
 
                .. note::
 
-                  See `Docker's installation documentation <https://docs.docker.com/engine/install/ubuntu/>`__ for alternative installation methods.
+                  Make sure to follow through to the **Enabling Docker support in WSL 2 distros** section and the last step of enabling **WSL Integration**.
+                  If you forget to do this, ``docker`` won't work in the WSL terminal.
 
-            2. Add your user to the `docker` group:
+               .. include:: snippets/wsl-home-dir.rst
 
-               .. code-block:: bash
 
-                  sudo gpasswd --add $USER docker
+            .. group-tab:: Ubuntu Linux
 
-            3. Restart your machine.
-            4. Install the Nextstrain CLI:
+               .. note:: Steps for other Linux distributions (Debian, CentOS, RHEL, etc.) will be similar, though specific commands may vary slightly.
 
-               .. code-block:: bash
+               Install Docker Engine using the standard Ubuntu package:
 
-                  curl -fsSL --proto '=https' https://nextstrain.org/cli/installer/linux | bash
+                  .. code-block:: bash
 
-            5. Follow the installer's final instructions to setup your shell config.
+                     sudo apt install docker.io
+
+               or see `Docker Engine's installation documentation <https://docs.docker.com/engine/install/ubuntu/>`__ for alternative methods.
+
+               Add your user to the ``docker`` group:
+
+                  .. code-block:: bash
+
+                     sudo gpasswd --add $USER docker
+
+               Log out and back in again for the group change to take effect.
+
+
+      2. Set up the runtime:
+
+         .. code-block:: none
+
+            nextstrain setup --set-default docker
+
+
+   .. group-tab:: Conda
+
+      .. note::
+
+         Due to installation constraints, there is no way to use Nextstrain's Conda runtime on Windows directly. Starting from the beginning, follow steps for **WSL on Windows** if the Conda runtime is desired, or use the **Docker** runtime instead.
+
+      Set up the runtime:
+
+      .. code-block:: none
+
+         nextstrain setup --set-default conda
 
 
    .. group-tab:: Ambient
 
-      .. tabs::
+      .. We use the phrase "custom Conda environment" to refer to the Conda environment managed by the user for use with the ambient runtime.
 
-         .. group-tab:: macOS
+      .. note:: The ambient runtime does not require a particular installation method; it will work as long as the programs required by Nextstrain are available.
+         The following describes how to accomplish this using a custom Conda environment as an example.
 
-            1. Install Miniconda:
+         If you already have Conda or Mamba installed and use it for other projects, you may need to adjust the instructions below.
 
-               .. The installer link is taken from https://docs.conda.io/en/latest/miniconda.html.
+      1. Install the necessary programs into a custom Conda environment you manage.
 
-               a. `Download the installer <https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.pkg>`_.
+         .. tabs::
 
-                  .. note::
+            .. group-tab:: macOS
 
-                        This is the Intel x86 64-bit installer, :ref:`which we recommend even for Mac computers with Apple silicon (e.g. M1) <why-intel-miniconda-installer-on-apple-silicon>`.
+               1. Install Miniconda:
 
-               b. Open the downloaded file and follow through installation prompts.
+                  .. The installer link is taken from https://docs.conda.io/en/latest/miniconda.html.
 
-            2. Open a terminal window.
-            3. Install Mamba on the ``base`` Conda environment:
+                  a. `Download the installer <https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.pkg>`_.
 
-               .. code-block:: bash
+                     .. note::
 
-                  conda install -n base -c conda-forge mamba --yes
-                  conda activate base
+                           This is the Intel x86 64-bit installer, :ref:`which we recommend even for Mac computers with Apple silicon (e.g. M1) <why-intel-miniconda-installer-on-apple-silicon>`.
 
-            4. Create a Conda environment named ``nextstrain``:
+                  b. Open the downloaded file and follow through installation prompts.
 
-               .. include:: snippets/conda-create-bash.rst
+               2. Open a new terminal window.
+               3. Install Mamba on the ``base`` Conda environment:
 
-            5. Install all the necessary software:
+                  .. code-block:: bash
 
-               .. include:: snippets/conda-install-full-bash.rst
+                     conda install -n base -c conda-forge mamba --yes
+                     conda activate base
 
+               4. Create a custom Conda environment named ``nextstrain``:
 
-         .. group-tab:: Windows
+                  .. include:: snippets/conda-create-bash.rst
 
-            .. note::
+               5. Install all the necessary software:
 
-               Due to installation constraints, there is no way to use the ambient runtime on Windows directly. Follow steps for **WSL on Windows** if the ambient runtime is desired, or use the **Docker**-based steps instead.
-
-
-         .. group-tab:: WSL on Windows
-
-            1. `Install Windows Subsystem for Linux (WSL) 2`_.
-            2. Open a WSL terminal by running **wsl** from the Start menu.
-            3. Install Miniconda:
-
-               .. code-block:: bash
-
-                  wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
-                  bash Miniconda3-latest-Linux-x86_64.sh
-                  # follow through installation prompts
-                  rm Miniconda3-latest-Linux-x86_64.sh
-
-            3. Install Mamba on the ``base`` Conda environment:
-
-               .. code-block:: bash
-
-                  conda install -n base -c conda-forge mamba --yes
-                  conda activate base
-
-            4. Create a Conda environment named ``nextstrain``:
-
-               .. include:: snippets/conda-create-bash.rst
-
-            5. Install all the necessary software:
-
-               .. include:: snippets/conda-install-full-bash.rst
-
-            .. include:: snippets/wsl-home-dir.rst
+                  .. include:: snippets/conda-install-full-bash.rst
 
 
-         .. group-tab:: Ubuntu Linux
+            .. group-tab:: Windows
 
-            .. note:: Steps for other Linux distributions (Debian, CentOS, RHEL, etc.) should be identical or very similar.
+               .. note::
 
-            1. Install Miniconda:
+                  Due to installation constraints, there is no way to use the ambient runtime on Windows directly. Starting from the beginning, follow steps for **WSL on Windows** if the ambient runtime is desired, or use the **Docker** runtime instead.
 
-               .. code-block:: bash
 
-                  wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
-                  bash Miniconda3-latest-Linux-x86_64.sh
-                  # follow through installation prompts
-                  rm Miniconda3-latest-Linux-x86_64.sh
+            .. group-tab:: WSL on Windows
 
-            2. Install Mamba on the ``base`` Conda environment:
+               1. Install Miniconda:
 
-               .. code-block:: bash
+                  .. code-block:: bash
 
-                  conda install -n base -c conda-forge mamba --yes
-                  conda activate base
+                     wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
+                     bash Miniconda3-latest-Linux-x86_64.sh
+                     # follow through installation prompts
+                     rm Miniconda3-latest-Linux-x86_64.sh
 
-            3. Create a Conda environment named ``nextstrain``:
+               2. Install Mamba on the ``base`` Conda environment:
 
-               .. include:: snippets/conda-create-bash.rst
+                  .. code-block:: bash
 
-            4. Install all the necessary software:
+                     conda install -n base -c conda-forge mamba --yes
+                     conda activate base
 
-               .. include:: snippets/conda-install-full-bash.rst
+               3. Create a custom Conda environment named ``nextstrain``:
+
+                  .. include:: snippets/conda-create-bash.rst
+
+               4. Install all the necessary software:
+
+                  .. include:: snippets/conda-install-full-bash.rst
+
+               .. include:: snippets/wsl-home-dir.rst
+
+
+            .. group-tab:: Ubuntu Linux
+
+               .. note:: Steps for other Linux distributions (Debian, CentOS, RHEL, etc.) should be identical or very similar.
+
+               1. Install Miniconda:
+
+                  .. code-block:: bash
+
+                     wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
+                     bash Miniconda3-latest-Linux-x86_64.sh
+                     # follow through installation prompts
+                     rm Miniconda3-latest-Linux-x86_64.sh
+
+               2. Install Mamba on the ``base`` Conda environment:
+
+                  .. code-block:: bash
+
+                     conda install -n base -c conda-forge mamba --yes
+                     conda activate base
+
+               3. Create a custom Conda environment named ``nextstrain``:
+
+                  .. include:: snippets/conda-create-bash.rst
+
+               4. Install all the necessary software:
+
+                  .. include:: snippets/conda-install-full-bash.rst
+
+
+      2. Set up the runtime:
+
+         .. code-block:: none
+
+            nextstrain setup --set-default ambient
+
 
       .. admonition:: For ambient runtime installs
          :class: hint
 
-         Whenever you open a new terminal window to work on a Nextstrain analysis, remember to activate the Conda environment with ``conda activate nextstrain``.
+         Whenever you open a new terminal window to work on a Nextstrain analysis, remember to activate the custom Conda environment with ``conda activate nextstrain``.
 
 
 
-Then, confirm that the installation worked.
-
-.. code-block:: bash
-
-  nextstrain check-setup --set-default
-
-The final output from the last command should look like this, where ``<runtime>`` is the runtime option (e.g. ``docker`` or ``ambient``) chosen in the first step:
+The final output from the last command should look like this, where ``<runtime>`` is the runtime option (e.g. Docker, Conda, or ambient) chosen in the first step:
 
 .. code-block:: none
 
   Setting default environment to <runtime>.
+
+  All good!  Set up of <runtime> complete.
 
 Optionally, :doc:`configure AWS Batch <cli:aws-batch>` if you'd like to run ``nextstrain build`` on AWS.
 
@@ -248,24 +303,38 @@ Update an existing installation
 
    .. group-tab:: Docker
 
-      Download the latest image with the Nextstrain CLI.
+      Update the Docker runtime:
 
       .. code-block:: bash
 
-         nextstrain update
+         nextstrain update docker
+
+      If the output notes that an update of the Nextstrain CLI itself is available, run the suggested command (after optionally reviewing the release notes).
+
+
+   .. group-tab:: Conda
+
+      Update the Conda runtime:
+
+      .. code-block:: bash
+
+         nextstrain update conda
 
       If the output notes that an update of the Nextstrain CLI itself is available, run the suggested command (after optionally reviewing the release notes).
 
 
    .. group-tab:: Ambient
 
-      Update the ``nextstrain`` Conda environment.
+      Update the ``nextstrain`` custom Conda environment.
 
       .. code-block:: bash
 
          mamba update -n base conda mamba
          conda activate nextstrain
          mamba update --all
+         nextstrain check-setup ambient
+
+      If the output of the final command notes that an update of the Nextstrain CLI itself is available, run the suggested command (after optionally reviewing the release notes).
 
 
 Troubleshoot a broken installation
@@ -274,6 +343,9 @@ Troubleshoot a broken installation
 .. tabs::
 
    .. group-tab:: Docker
+
+      Running ``nextstrain check-setup docker`` will also report potential issues.
+      Make sure there are no errors or warnings reported.
 
       The Docker runtime requires that the Docker service is running on your computer behind the scenes.
       If you see a message like::
@@ -284,13 +356,29 @@ Troubleshoot a broken installation
       On macOS and Windows, try quitting Docker Desktop (if it's open) and restarting it.
       On Linux, try running ``sudo systemctl restart docker``.
 
-      Running ``nextstrain check-setup`` will also report potential issues.
-      Make sure there are no errors or warnings reported for the Docker runtime.
+
+   .. group-tab:: Conda
+
+      Running ``nextstrain check-setup conda`` will report potential issues.
+      Make sure there are no errors or warnings reported.
+
+      You can forcibly setup the Conda runtime again by running:
+
+      .. code-block:: bash
+
+         nextstrain setup --force conda
+
+      This should rarely be necessary, but may help if you find yourself with a broken runtime.
 
 
    .. group-tab:: Ambient
 
-      If Conda fails to install or update Nextstrain using the commands above, it's possible that Conda itself is out-of-date or that Conda cannot figure out how to resolve the environment's dependencies.
+      Running ``nextstrain check-setup ambient`` will report potential issues.
+      Make sure there are no errors or warnings reported.
+
+      Ensure that you've activated your custom Conda environment with ``conda activate nextstrain``.
+
+      If Conda fails to install or update Nextstrain using the commands in the other sections above, it's possible that Conda itself is out-of-date or that Conda cannot figure out how to resolve the environment's dependencies.
       Starting from scratch often fixes problems with Conda environments.
       To start over with a new Nextstrain environment, delete your current environment.
 
@@ -314,27 +402,18 @@ Uninstall
 We do not have an automated uninstall process currently.
 Instead, follow these manual steps:
 
-.. tabs::
+   1. If the directory :file:`~/.nextstrain` exists, remove it.
+   2. If using the Docker runtime, remove all ``nextstrain/…`` Docker images::
 
-   .. group-tab:: Docker
+         docker image rm $(docker image ls -q "nextstrain/*")
 
-      1. If the directory :file:`~/.nextstrain` exists, remove it.
-      2. Remove all ``nextstrain/…`` Docker images::
+      Optionally, uninstall Docker if only used for Nextstrain.
+   3. If using the ambient runtime, remove the ``nextstrain`` custom Conda environment::
 
-            docker image rm $(docker image ls -q "nextstrain/*")
+         conda env remove -n nextstrain
 
-      3. Optionally, uninstall Docker if only used for Nextstrain.
-      4. On Windows, optionally, uninstall WSL if only used for Nextstrain.
-
-   .. group-tab:: Ambient
-
-      1. If the directory :file:`~/.nextstrain` exists, remove it.
-      2. Remove the ``nextstrain`` Conda environment::
-
-            conda env remove -n nextstrain
-
-      3. Optionally, uninstall Conda if only used for Nextstrain.
-      4. On Windows, optionally, uninstall WSL if only used for Nextstrain.
+      Optionally, uninstall Conda if only used for Nextstrain.
+   4. On Windows, optionally, uninstall WSL if only used for Nextstrain.
 
 Next steps
 ==========

--- a/src/reference/faq.rst
+++ b/src/reference/faq.rst
@@ -114,8 +114,8 @@ The ambient runtime is still a good option for users who wish to customize their
 How is the new Conda runtime different from the old "native" runtime?
 ---------------------------------------------------------------------------
 
-Summary: The Conda runtime, like the Docker runtime, is fully managed by the Nextstrain CLI.
+The Conda runtime, like the Docker runtime, is fully managed by the Nextstrain CLI.
+The CLI manages the versioning of an isolated Conda environment separate from any existing Conda installation (if present).
+It ensures all the software tools used for Nextstrain-related analysis are available and handles updates to them via the ``nextstrain update`` command (like the Docker runtime).
 
-In Docker, the CLI manages versioning of the ``nextstrain/base`` Docker image, which comes packaged with common software tools used for Nextstrain-related analysis.
-
-In Conda, the CLI manages the versioning of an isolated Conda environment separate from any existing Conda installation (if present). If you wish to use your existing Conda environment from the old native runtime or set up a new Conda environment, please refer to the ambient runtime usage instructions on the installation page.
+If you wish to use your existing ``nextstrain`` Conda environment from the previously-named native runtime or set up a new Conda environment yourself, please refer to the ambient runtime usage instructions on the installation page.

--- a/src/reference/faq.rst
+++ b/src/reference/faq.rst
@@ -101,7 +101,7 @@ Up until Nextstrain CLI version 5.0.0, the name of the ``native`` runtime has be
 The ``ambient`` runtime is "native" in that sense, but it puts all the software maintenance burden on the user. This means:
 
 1. There is a lengthy setup process which requires installing external software (Conda, Mamba). Additionally, there is no way for us to provide accurate setup steps for users who already have Conda installed, as there are various methods of installing Conda.
-2. It is up to you as the creator of the ``nextstrain`` Conda environment to know (1) how to activate it, (2) when to update it, and (3) how to update it.
+2. It is up to you as the creator of the ``nextstrain`` Conda environment to know (a) how to activate it, (b) when to update it, and (c) how to update it.
 
 So really, the ``ambient`` runtime is any environment that has been set up with all of the required software available on your local ``PATH``. We chose Conda in the installation instructions since some users may already be familiar with it, and it is simpler than using individual package managers for the various required software (e.g. ``pip``, ``npm``).
 

--- a/src/reference/faq.rst
+++ b/src/reference/faq.rst
@@ -91,31 +91,31 @@ This will ensure that all commands in the active Conda environment are run using
 
 .. _what-happened-to-the-native-runtime:
 
-What happened to the ``native`` runtime?
+What happened to the "native" runtime?
 ----------------------------------------
 
-Up until Nextstrain CLI version 5.0.0, the name of the ``native`` runtime has been debated internally. In CLI version 5.0.0, **it was renamed to** ``ambient`` and we will use the new name going forwards.
+Up until Nextstrain CLI version 5.0.0, the name of the "native" runtime has been debated internally. In CLI version 5.0.0, **it was renamed to "ambient"** and we will use the new name going forwards.
 
 "Native" as a software term is typically used to describe software that can run without emulation, in other words optimized for your computer's processor.
 
-The ``ambient`` runtime is "native" in that sense, but it puts all the software maintenance burden on the user. This means:
+The ambient runtime is native in that sense, but it puts all the software maintenance burden on the user. This means:
 
 1. There is a lengthy setup process which requires installing external software (Conda, Mamba). Additionally, there is no way for us to provide accurate setup steps for users who already have Conda installed, as there are various methods of installing Conda.
 2. It is up to you as the creator of the ``nextstrain`` Conda environment to know (a) how to activate it, (b) when to update it, and (c) how to update it.
 
-So really, the ``ambient`` runtime is any environment that has been set up with all of the required software available on your local ``PATH``. We chose Conda in the installation instructions since some users may already be familiar with it, and it is simpler than using individual package managers for the various required software (e.g. ``pip``, ``npm``).
+So really, the ambient runtime is any environment that has been set up with all of the required software available on your local ``PATH``. We chose Conda in the installation instructions since some users may already be familiar with it, and it is simpler than using individual package managers for the various required software (e.g. ``pip``, ``npm``).
 
-Most importantly, Nextstrain CLI version 5.0.0 provides a **new** ``conda`` **runtime that runs natively** without putting all of the software maintenance burden on users. This means the ``ambient`` runtime is no longer the only "native" runtime, and we will recommend new users to use the ``conda`` runtime instead of ``ambient``.
+Most importantly, Nextstrain CLI version 5.0.0 provides a **new Conda runtime that runs natively** without putting all of the software maintenance burden on users. This means the ambient runtime is no longer the only "native" runtime, and we will recommend new users to use the Conda runtime instead of ambient.
 
-``ambient`` is still a good option for users who wish to customize their environment to include other software used in their workflows.
+The ambient runtime is still a good option for users who wish to customize their environment to include other software used in their workflows.
 
 .. _new-conda-runtime-vs-old-native-runtime:
 
-How is the new ``conda`` runtime different from the old ``native`` runtime?
+How is the new Conda runtime different from the old "native" runtime?
 ---------------------------------------------------------------------------
 
-Summary: ``conda``, like ``docker``, is fully managed by the Nextstrain CLI.
+Summary: The Conda runtime, like the Docker runtime, is fully managed by the Nextstrain CLI.
 
-In ``docker``, the CLI manages versioning of the ``nextstrain/base`` Docker image, which comes packaged with common software tools used for Nextstrain-related analysis.
+In Docker, the CLI manages versioning of the ``nextstrain/base`` Docker image, which comes packaged with common software tools used for Nextstrain-related analysis.
 
-In ``conda``, the CLI manages the versioning of an isolated Conda environment separate from any existing Conda installation (if present). If you wish to use your existing Conda environment from the old ``native`` runtime or set up a new Conda environment, please refer to the ``ambient`` runtime usage instructions on the installation page.
+In Conda, the CLI manages the versioning of an isolated Conda environment separate from any existing Conda installation (if present). If you wish to use your existing Conda environment from the old native runtime or set up a new Conda environment, please refer to the ambient runtime usage instructions on the installation page.

--- a/src/reference/faq.rst
+++ b/src/reference/faq.rst
@@ -94,7 +94,8 @@ This will ensure that all commands in the active Conda environment are run using
 What happened to the "native" runtime?
 ----------------------------------------
 
-Up until Nextstrain CLI version 5.0.0, the name of the "native" runtime has been debated internally. In CLI version 5.0.0, **it was renamed to "ambient"** and we will use the new name going forwards.
+The "native" runtime was **renamed to "ambient"** in Nextstrain CLI version 5.0.0, and we will use the new name going forwards.
+The suitability of the "native" name had long been discussed within the Nextstrain team.
 
 "Native" as a software term is typically used to describe software that can run without emulation, in other words optimized for your computer's processor.
 

--- a/src/reference/faq.rst
+++ b/src/reference/faq.rst
@@ -17,11 +17,13 @@ There are many ways to install Nextstrain, and we aim to simplify the installati
 What are Docker, Conda, Mamba, WSL, etc.?
 -----------------------------------------
 
-`Docker <https://docker.com/>`_ is a container system available for all platforms.
-When you use Docker to run Nextstrain components, you don’t need to manage any other Nextstrain software dependencies as validated versions are already bundled into `a container image by the Nextstrain team <https://github.com/nextstrain/docker-base/>`_.
+`Docker <https://docker.com/>`_ is a container management system that allows you to run isolated software images without disrupting or *being* disrupted by other software you have installed (e.g., on your computer, your shared cluster, etc.).
+When you use Nextstrain's Docker runtime, you need to install Docker yourself but don't need to manage any other Nextstrain software dependencies as validated versions are already bundled into `a container image by the Nextstrain team <https://github.com/nextstrain/docker-base/>`__.
 
-`Conda <https://docs.conda.io/en/latest/>`_ is a package and environment management system that allows you to install Python and other software into controlled environments without disrupting other software you have installed (e.g., on your computer, your shared cluster, etc.).
+`Conda <https://docs.conda.io/en/latest/>`_ is a package and environment management system that allows you to install Python and other software into controlled environments without disrupting other software you have installed.
 Miniconda is the minimal installation of the ``conda`` command, the command-line interface to Conda.
+When you use Nextstrain's Conda runtime, you don't need to install Conda yourself or manage any other Nextstrain software dependencies as validated versions are already locked into `a package by the Nextstrain team <https://github.com/nextstrain/conda-base/>`__.
+When you use Nextstrain's ambient runtime, we provide an example of how to set it up using Conda.
 
 `Mamba <https://github.com/mamba-org/mamba>`_ is a drop-in replacement for most ``conda`` functionality that provides faster installation times, especially for complex environments like the one Nextstrain requires.
 
@@ -31,24 +33,25 @@ Nextstrain's installation guide works with WSL 2 but not WSL 1.
 
 .. _choosing-a-runtime:
 
-Should I choose the Docker or Ambient runtime?
-----------------------------------------------
+Should I choose the Docker, Conda, or ambient runtime?
+------------------------------------------------------
 
-The two runtimes provide the same experience running Nextstrain workflows with ``nextstrain build`` (and most other ``nextstrain`` commands) but vary in installation and update methods and predictability/stability over time.
+The three runtimes provide the same experience running Nextstrain workflows with ``nextstrain build`` (and most other ``nextstrain`` commands) but vary in installation and update methods and predictability/stability over time.
 
 There's not one right answer for everyone or every situation.
-That's why we provide both options (and will potentially provide more in the future).
-The Nextstrain team uses both runtimes extensively.
+That's why we provide runtime options (and will potentially provide more in the future).
+The Nextstrain team uses all runtimes extensively.
 
 Your preference is perhaps the best reason to choose one vs. the other.
 
    - If you have a preference for containers, then choose the Docker runtime.
-   - If you have a preference for Conda, then choose the ambient runtime.
+   - If you have a preference for Conda (or dispreference for containers), then choose the Conda runtime.
+   - If you have a preference for managing software environments yourself, then choose the ambient runtime.
    - If you don't have a preference, choose the one you have the most past experience with.
-   - If you have neither preference nor experience, we recommend choosing the Docker runtime because it has less to manage and is more predictable/stable over time.
+   - If you have neither preference nor experience, we recommend choosing the Docker runtime because it is the most stable and reproducible over time.
 
-You can also install and use both runtimes on the same computer, if you want to use them contextually.
-For example, ``nextstrain`` commands let you select a different runtime than your default using command-line options (``--docker`` or ``--ambient``).
+You can also install and use multiple runtimes on the same computer, if you want to use them contextually.
+For example, ``nextstrain`` commands let you select a different runtime than your default using command-line options (``--docker``, ``--conda``, or ``--ambient``).
 
 If you pick one and later realize you want to switch, you can go back and install the other and make it your default.
 

--- a/src/snippets/conda-install-full-bash.rst
+++ b/src/snippets/conda-install-full-bash.rst
@@ -1,5 +1,5 @@
 .. code-block:: bash
 
     mamba install --yes \
-        nextstrain-cli augur auspice nextalign nextclade \
+        augur auspice nextalign nextclade \
         snakemake git epiweeks pangolin pangolearn

--- a/src/snippets/nextstrain-setup-conda.rst
+++ b/src/snippets/nextstrain-setup-conda.rst
@@ -1,0 +1,5 @@
+Set up the runtime:
+
+.. code-block:: none
+
+   nextstrain setup --set-default conda


### PR DESCRIPTION
See commit messages for details and read [the preview](https://nextstrain--138.org.readthedocs.build/en/138/install.html).

Related to https://github.com/nextstrain/cli/pull/218 and others in the CLI repo.
Related to #131.

### Testing

- [x] Checks pass
- [x] Preview looks good
