### PR TITLE
Use centralized sync-rtd-redirects workflow

### DIFF
--- a/.github/workflows/sync-redirects.yaml
+++ b/.github/workflows/sync-redirects.yaml
@@ -13,18 +13,10 @@ on:
 
 jobs:
   sync:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-
-      - name: Upgrade Python toolchain
-        run: python3 -m pip install --upgrade pip setuptools wheel
-
-      - name: Install readthedocs-cli
-        run: python3 -m pip install readthedocs-cli
-
-      - name: Sync redirects
-        run: rtd projects nextstrain redirects sync -f redirects.yml --wet-run
-        env:
-          RTD_TOKEN: ${{ secrets.RTD_TOKEN }}
+    name: rtd redirects
+    uses: nextstrain/.github/.github/workflows/sync-rtd-redirects.yaml@master
+    with:
+      project: nextstrain
+      file: redirects.yml
+    secrets:
+      RTD_TOKEN: ${{ secrets.RTD_TOKEN }}


### PR DESCRIPTION
A central copy is easier to maintain over time now that this workflow is
proliferating across our repos.

See also https://github.com/nextstrain/.github/pull/30.

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Manually invoked workflow works

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
