### PR TITLE
install: Document that Rosetta 2 must be enabled for arm64 Macs and how to do so

### DIFF
--- a/src/install.rst
+++ b/src/install.rst
@@ -39,6 +39,18 @@ First, install Nextstrain CLI.
 
       You can launch a Terminal by clicking the Launchpad icon in the Dock, typing ``terminal`` in the search field, and clicking Terminal.
 
+      .. warning::
+
+         If the installation errors with the message "**Bad CPU type in executable**", then you're likely using a newer Mac with an `Apple silicon chip <https://support.apple.com/en-us/HT211814>`_ (e.g. M1).
+
+         `Enable Rosetta 2 <https://support.apple.com/en-us/HT211861>`__ with:
+
+         .. code-block:: bash
+
+            softwareupdate --install-rosetta
+
+         and then retry the installation.
+         Rosetta 2 is required for both Nextstrain CLI itself and our runtimes.
 
    .. group-tab:: Windows
 


### PR DESCRIPTION
Related to [this Slack thread](https://bedfordlab.slack.com/archives/C01LCTT7JNN/p1670963819691499).

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Command allowed standalone Nextstrain CLI setup to succeed
- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
