### PR TITLE
install: Revise instructions for Rosetta 2 now that the installer checks for it

### DIFF
--- a/src/install.rst
+++ b/src/install.rst
@@ -39,18 +39,11 @@ First, install Nextstrain CLI.
 
       You can launch a Terminal by clicking the Launchpad icon in the Dock, typing ``terminal`` in the search field, and clicking Terminal.
 
-      .. warning::
+      .. note::
 
-         If the installation errors with the message "**Bad CPU type in executable**", then you're likely using a newer Mac with an `Apple silicon chip <https://support.apple.com/en-us/HT211814>`_ (e.g. M1).
-
-         `Enable Rosetta 2 <https://support.apple.com/en-us/HT211861>`__ with:
-
-         .. code-block:: bash
-
-            softwareupdate --install-rosetta
-
-         and then retry the installation.
-         Rosetta 2 is required for both Nextstrain CLI itself and our runtimes.
+         On newer Macs with an `Apple silicon chip <https://support.apple.com/en-us/HT211814>`_ (e.g. M1), `Rosetta 2 <https://support.apple.com/en-us/HT211861>`__ is required for both Nextstrain CLI itself and our runtimes.
+         Most of the time, Rosetta 2 will already be enabled.
+         If not, the installer will ask you to first enable Rosetta 2 and then retry the installation.
 
    .. group-tab:: Windows
 


### PR DESCRIPTION
Leaves it to the installer to instruct how to enable Rosetta 2 and generally makes the warning a bit less obtrusive.

Related-to: <https://github.com/nextstrain/cli/pull/247>
Related-to: <https://github.com/nextstrain/docs.nextstrain.org/pull/147>

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Preview is ok
- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
