### PR TITLE
Remove warning about Docker runtime on macOS

### DIFF
--- a/src/install.rst
+++ b/src/install.rst
@@ -97,10 +97,6 @@ Then, install a Nextstrain runtime.
 
             .. group-tab:: macOS
 
-               .. warning::
-
-                  If using a newer Mac with an `Apple silicon chip <https://support.apple.com/en-us/HT211814>`_ (e.g. M1), the **Conda** runtime is recommended due to slowness with the Docker runtime. `We are considering ways to improve this <https://github.com/nextstrain/docker-base/issues/35>`_.
-
                `Install Docker Desktop for macOS <https://docs.docker.com/desktop/install/mac-install/>`_.
 
 


### PR DESCRIPTION
### Description of proposed changes

<!-- What is the goal of this pull request? What does this pull request change? -->

This is not relevant anymore now that the linked issue is closed (with the introduction of a linux/arm64 variant of the Docker image).

### Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

Prompted by closure of https://github.com/nextstrain/docker-base/issues/35

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] [Preview](https://nextstrain--155.org.readthedocs.build/en/155/install.html) looks good

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
