### PR TITLE
Update runtime-dependent setup step

### DIFF
--- a/src/tutorials/creating-a-workflow.rst
+++ b/src/tutorials/creating-a-workflow.rst
@@ -33,15 +33,27 @@ Setup
 
       mkdir -p results/
 
-3. Additionally, if you installed Nextstrain with the :term:`Docker runtime<runtime>`, start Docker and enter the runtime.
+3. Enter a prompt with Nextstrain tools available. This varies by runtime.
 
-   .. code-block:: bash
+   .. tabs::
 
-      nextstrain shell .
+      .. group-tab:: Docker, Conda
 
-   .. note::
+         .. code-block:: bash
 
-      The dot (``.``) as the last argument indicates that your current directory (``zika-tutorial/``) is the working directory. Your command prompt will change to indicate you are in the Docker runtime. If you want to leave the runtime, run the command ``exit``.
+            nextstrain shell .
+
+         .. note::
+
+            The dot (``.``) as the last argument indicates that your current directory (``zika-tutorial/``) is the working directory. Your command prompt will change to indicate you are in a Nextstrain shell, which provides access to commands such as ``augur`` and ``auspice``. If you want to leave the Nextstrain shell, run the command ``exit``.
+
+      .. group-tab:: Ambient (advanced)
+
+         This varies depending on how your ambient runtime is set up. If you've installed tools into a custom Conda environment, activate it.
+
+         .. code-block:: bash
+
+            conda activate <your-environment-name>
 
 Run a Nextstrain Build
 ======================


### PR DESCRIPTION
_preview: [before](https://docs.nextstrain.org/en/latest/tutorials/creating-a-workflow.html#setup), [after](https://nextstrain--159.org.readthedocs.build/en/159/tutorials/creating-a-workflow.html#setup)_

### Description of proposed changes

The step now applies to all runtime setups. Previously, it relied on inaccurate assumptions:

1. It only supported 2 runtimes, Docker and ambient.
2. If using the ambient runtime, it already had tools available (e.g. a Conda environment is already active).

### Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

N/A

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
