### PR TITLE
Add section on using the config var

### DIFF
--- a/src/reference/snakemake-style-guide.rst
+++ b/src/reference/snakemake-style-guide.rst
@@ -46,3 +46,18 @@ Avoid the ``message`` rule attribute
 -  When the ``message`` attribute is defined, Snakemake suppresses other
    critical details that otherwise get displayed by default (e.g., job
    id, rule name, input, output, etc.).
+
+Access ``config`` values appropriately
+======================================
+
+Use the appropriate method to access configuration in the ``config``
+global variable. 3 ways are supported, but only 2 should be used:
+
+1. ``config[key]``: Use this when the key is required, or a default is
+   specified in a pre-loaded configuration file.
+
+2. ``config.get(key, default)``: Use this when the key is optional.
+
+3. ``config.get(key)``: Never use this. All use cases should be covered
+   by (1) and (2). Using this will only mask errors that may be due to a
+   missing required key.


### PR DESCRIPTION
_[preview](https://nextstrain--163.org.readthedocs.build/en/163/reference/snakemake-style-guide.html#access-config-values-appropriately)_

### Description of proposed changes

Adding something that I applied in https://github.com/nextstrain/monkeypox/commit/c10fde839c21c18ec96dad82f66d9c6c5737540c which seems fit for this style guide.

### Related issue(s)

Prompted by https://github.com/nextstrain/monkeypox/pull/161#discussion_r1270988193.

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
