### PR TITLE
Migrate blab/styleguide to the Snakemake style guide

### DIFF
--- a/src/reference/snakemake-style-guide.rst
+++ b/src/reference/snakemake-style-guide.rst
@@ -194,3 +194,7 @@ Always use relative paths
 Relative paths (paths that don't start with ``/``) mean that anyone can
 run the build without running into portability issues caused by paths
 specific to your computer.
+
+See the `Snakemake documentation
+<https://snakemake.readthedocs.io/en/stable/project_info/faq.html#how-does-snakemake-interpret-relative-paths>`__
+for how relative paths are interpreted depending on context.

--- a/src/reference/snakemake-style-guide.rst
+++ b/src/reference/snakemake-style-guide.rst
@@ -43,9 +43,9 @@ Do this instead of using ``rule`` variables.
 Avoid the ``message`` rule attribute
 ====================================
 
--  When the ``message`` attribute is defined, Snakemake suppresses other
-   critical details that otherwise get displayed by default (e.g., job
-   id, rule name, input, output, etc.).
+When the ``message`` attribute is defined, Snakemake suppresses other critical
+details that otherwise get displayed by default (e.g., job id, rule name,
+input, output, etc.).
 
 Access ``config`` values appropriately
 ======================================

--- a/src/reference/snakemake-style-guide.rst
+++ b/src/reference/snakemake-style-guide.rst
@@ -75,30 +75,20 @@ Example:
    params:
        key=lambda w: config["value_may_contain_curlies"]
 
-Use a config.yaml file
-======================
+Use a YAML configuration file and allow for overrides
+=====================================================
 
-Configuration is data and should live inside a YAML file named
-``config.yaml``. You can access it in your Snakefile by including the
-line:
-
-.. code-block:: python
-
-   configfile: "config.yaml"
-
-and then using the ``config`` dictionary provided in scope afterwards.
-
-Allow for easy config overrides
-===============================
-
-By including the following snippet in your Snakefile, you can allow for
-optional configuration overrides using the ``--configfile`` option to
-``snakemake``.
+Configuration is data and should live inside YAML files. By including the
+following snippet in your Snakefile, you can provide default values and allow
+for additional entries or overrides via the ``--configfile`` or ``--config``
+options to ``snakemake``.
 
 .. code-block:: python
 
-   if not config:
-       configfile: "config.yaml"
+   configfile: "defaults.yaml"
+
+Configuration values are available as a ``config`` dictionary provided in scope
+afterwards.
 
 Use Snakemake ``params:`` block to map into ``config`` dictionary
 =================================================================

--- a/src/reference/snakemake-style-guide.rst
+++ b/src/reference/snakemake-style-guide.rst
@@ -40,40 +40,23 @@ Do this instead of using ``rule`` variables.
    (`see ncov PR 877 <https://github.com/nextstrain/ncov/pull/877>`__,
    for an example).
 
+Always use relative paths
+=========================
+
+Relative paths (paths that don't start with ``/``) mean that anyone can
+run the build without running into portability issues caused by paths
+specific to your computer.
+
+See the `Snakemake documentation
+<https://snakemake.readthedocs.io/en/stable/project_info/faq.html#how-does-snakemake-interpret-relative-paths>`__
+for how relative paths are interpreted depending on context.
+
 Avoid the ``message`` rule attribute
 ====================================
 
 When the ``message`` attribute is defined, Snakemake suppresses other critical
 details that otherwise get displayed by default (e.g., job id, rule name,
 input, output, etc.).
-
-Access ``config`` values appropriately
-======================================
-
-Use the appropriate method to access configuration in the ``config``
-global variable. 3 ways are supported, but only 2 should be used:
-
-1. ``config[key]``: Use this when the key is required, or a default is
-   specified in a pre-loaded configuration file.
-
-2. ``config.get(key, default)``: Use this when the key is optional.
-
-3. ``config.get(key)``: Never use this. All use cases should be covered
-   by (1) and (2). Using this will only mask errors that may be due to a
-   missing required key.
-
-Use lambda on ``params`` that may have ``{`` or ``}`` in the value
-==================================================================
-
-If the value passed to a param contains curly braces, Snakemake will attempt to
-resolve it as a wildcard. To keep the value as-is, `use a lambda expression <https://github.com/snakemake/snakemake/issues/2166#issuecomment-1464202922>`__.
-
-Example:
-
-.. code-block:: python
-
-   params:
-       key=lambda w: config["value_may_contain_curlies"]
 
 Use a YAML configuration file and allow for overrides
 =====================================================
@@ -89,6 +72,21 @@ options to ``snakemake``.
 
 Configuration values are available as a ``config`` dictionary provided in scope
 afterwards.
+
+Access ``config`` values appropriately
+======================================
+
+Use the appropriate method to access configuration in the ``config``
+global variable. 3 ways are supported, but only 2 should be used:
+
+1. ``config[key]``: Use this when the key is required, or a default is
+   specified in a pre-loaded configuration file.
+
+2. ``config.get(key, default)``: Use this when the key is optional.
+
+3. ``config.get(key)``: Never use this. All use cases should be covered
+   by (1) and (2). Using this will only mask errors that may be due to a
+   missing required key.
 
 Use Snakemake ``params:`` block to map into ``config`` dictionary
 =================================================================
@@ -116,6 +114,19 @@ command. This has several benefits:
 -  Snakemake can automatically discover which rules have parameter
    values that are different than the last run and show what output
    files are affected (``--list-params-changes``).
+
+Use lambda on ``params`` that may have ``{`` or ``}`` in the value
+==================================================================
+
+If the value passed to a param contains curly braces, Snakemake will attempt to
+resolve it as a wildcard. To keep the value as-is, `use a lambda expression <https://github.com/snakemake/snakemake/issues/2166#issuecomment-1464202922>`__.
+
+Example:
+
+.. code-block:: python
+
+   params:
+       key=lambda w: config["value_may_contain_curlies"]
 
 Always use quoted (:q) interpolations
 =====================================
@@ -172,14 +183,3 @@ Example:
            --output-sequences {output.sequences:q} \
            --output-metadata {output.metadata:q}
        """
-
-Always use relative paths
-=========================
-
-Relative paths (paths that don't start with ``/``) mean that anyone can
-run the build without running into portability issues caused by paths
-specific to your computer.
-
-See the `Snakemake documentation
-<https://snakemake.readthedocs.io/en/stable/project_info/faq.html#how-does-snakemake-interpret-relative-paths>`__
-for how relative paths are interpreted depending on context.

--- a/src/reference/snakemake-style-guide.rst
+++ b/src/reference/snakemake-style-guide.rst
@@ -74,3 +74,143 @@ Example:
 
    params:
        key=lambda w: config["value_may_contain_curlies"]
+
+Use a config.yaml file
+======================
+
+Configuration is data and should live inside a YAML file named
+``config.yaml``. You can access it in your Snakefile by including the
+line:
+
+::
+
+   configfile: "config.yaml"
+
+and then using the ``config`` dictionary provided in scope afterwards.
+
+Allow for easy local config overrides
+=====================================
+
+By including the following snippet in your Snakefile, you can allow for
+optional, local configuration overrides which are more persistent than
+using ``--config`` options to ``snakemake``.
+
+::
+
+   from pathlib import Path
+
+   if Path("config_local.yaml").is_file():
+       configfile: "config_local.yaml"
+
+If you do this, you should also add a ``/config_local.yaml`` line to
+your repository's top-level ``.gitignore`` file.
+
+Use Snakemake ``params:`` block to map into ``config`` dictionary
+=================================================================
+
+For example, do this:
+
+::
+
+   params:
+       name = config["name"]
+   shell:
+       "echo {params.name:q}"
+
+instead of using the ``config`` dictionary directly in the shell
+command. This has several benefits:
+
+-  Interpolation of dictionary lookups in the shell commands is
+   non-standard and confusing. (You have to use ``{config[name]}``, for
+   example. Note that the dictionary key is unquoted.)
+
+-  Param definitions can use arbitrary Python expressions, so you can do
+   more complicated things than you can with direct interpolation, such
+   as list comprehensions.
+
+-  Snakemake can automatically discover which rules have parameter
+   values that are different than the last run and show what output
+   files are affected (``--list-params-changes``).
+
+Always use quoted (:q) interpolations
+=====================================
+
+When building shell commands to run, Snakemake does not by default
+properly quote interpolated values. This works fine if the interpolated
+value doesn't contain spaces or other special shell metacharacters (like
+quotes or backslashes), but it is fragile and a time-bomb waiting to
+break on future values.
+
+Standard best practice in any language or environment is to always quote
+parameters in generated shell commands. Snakemake supports this using
+the ``:q`` modifier for interpolation:
+
+::
+
+   params:
+       file = "filename with spaces.txt"
+   shell:
+       "wc -l {params.file:q}"
+
+Not quoting these values is also a security risk.
+
+It may be tempting to make an exception for parameters with multiple
+values where you want each become a separate command-line argument, such
+as a parameter listing three filenames. In this case, however, it's
+recommended that you make the parameter a list instead of a single
+string. Snakemake will interpolate it correctly:
+
+::
+
+   params:
+       files = ["a.txt", "b.txt", "c.txt"]
+   shell:
+       "wc -l {params.files:q}"
+
+Use triple-quoted command definitions
+=====================================
+
+Using triple-quoted (``"""`` or ``'''``) command definitions make it
+much easier to build readable commands with one-option per line. It also
+avoids any nested quoting issues if you need to use literal single or
+double quotes in your command.
+
+Example:
+
+::
+
+   shell:
+       """
+       augur parse \
+           --sequences {input:q} \
+           --fields {params.fields:q} \
+           --output-sequences {output.sequences:q} \
+           --output-metadata {output.metadata:q}
+       """
+
+Provide descriptive messages for each rule
+==========================================
+
+Rules support a ``message:`` block which defines a string to print when
+the rule is run. This is very helpful for tracking build progress and in
+general describing what's happening. Note that you can use interpolation
+within the message, so you can surface important parameter values or
+conditional inputs or anything else that might be useful.
+
+Example:
+
+::
+
+   rule traits:
+       message: "Inferring ancestral traits {params.columns!s}"
+
+Always use relative paths
+=========================
+
+Relative paths (paths that don't start with ``/``) mean that anyone can
+run the build without running into portability issues caused by paths
+specific to your computer.
+
+Our convention for builds is that Nextstrain components are available
+locally if needed as sibling directories, for example ``../fauna/`` and
+``../auspice/``.

--- a/src/reference/snakemake-style-guide.rst
+++ b/src/reference/snakemake-style-guide.rst
@@ -82,7 +82,7 @@ Configuration is data and should live inside a YAML file named
 ``config.yaml``. You can access it in your Snakefile by including the
 line:
 
-::
+.. code-block:: python
 
    configfile: "config.yaml"
 
@@ -105,7 +105,7 @@ Use Snakemake ``params:`` block to map into ``config`` dictionary
 
 For example, do this:
 
-::
+.. code-block:: python
 
    params:
        name = config["name"]
@@ -140,7 +140,7 @@ Standard best practice in any language or environment is to always quote
 parameters in generated shell commands. Snakemake supports this using
 the ``:q`` modifier for interpolation:
 
-::
+.. code-block:: python
 
    params:
        file = "filename with spaces.txt"
@@ -155,7 +155,7 @@ as a parameter listing three filenames. In this case, however, it's
 recommended that you make the parameter a list instead of a single
 string. Snakemake will interpolate it correctly:
 
-::
+.. code-block:: python
 
    params:
        files = ["a.txt", "b.txt", "c.txt"]
@@ -172,7 +172,7 @@ double quotes in your command.
 
 Example:
 
-::
+.. code-block:: python
 
    shell:
        """

--- a/src/reference/snakemake-style-guide.rst
+++ b/src/reference/snakemake-style-guide.rst
@@ -96,9 +96,11 @@ For example, do this:
 .. code-block:: python
 
    params:
-       name = config["name"]
+       name = lambda _: config["name"]
    shell:
-       "echo {params.name:q}"
+       """
+       echo {params.name:q}
+       """
 
 instead of using the ``config`` dictionary directly in the shell
 command. This has several benefits:
@@ -146,7 +148,9 @@ the ``:q`` modifier for interpolation:
    params:
        file = "filename with spaces.txt"
    shell:
-       "wc -l {params.file:q}"
+       """
+       wc -l {params.file:q}
+       """
 
 Not quoting these values is also a security risk.
 
@@ -161,7 +165,9 @@ string. Snakemake will interpolate it correctly:
    params:
        files = ["a.txt", "b.txt", "c.txt"]
    shell:
-       "wc -l {params.files:q}"
+       """
+       wc -l {params.files:q}
+       """
 
 Use triple-quoted command definitions
 =====================================

--- a/src/reference/snakemake-style-guide.rst
+++ b/src/reference/snakemake-style-guide.rst
@@ -88,22 +88,17 @@ line:
 
 and then using the ``config`` dictionary provided in scope afterwards.
 
-Allow for easy local config overrides
-=====================================
+Allow for easy config overrides
+===============================
 
 By including the following snippet in your Snakefile, you can allow for
-optional, local configuration overrides which are more persistent than
-using ``--config`` options to ``snakemake``.
+optional configuration overrides using the ``--configfile`` option to
+``snakemake``.
 
-::
+.. code-block:: python
 
-   from pathlib import Path
-
-   if Path("config_local.yaml").is_file():
-       configfile: "config_local.yaml"
-
-If you do this, you should also add a ``/config_local.yaml`` line to
-your repository's top-level ``.gitignore`` file.
+   if not config:
+       configfile: "config.yaml"
 
 Use Snakemake ``params:`` block to map into ``config`` dictionary
 =================================================================

--- a/src/reference/snakemake-style-guide.rst
+++ b/src/reference/snakemake-style-guide.rst
@@ -194,7 +194,3 @@ Always use relative paths
 Relative paths (paths that don't start with ``/``) mean that anyone can
 run the build without running into portability issues caused by paths
 specific to your computer.
-
-Our convention for builds is that Nextstrain components are available
-locally if needed as sibling directories, for example ``../fauna/`` and
-``../auspice/``.

--- a/src/reference/snakemake-style-guide.rst
+++ b/src/reference/snakemake-style-guide.rst
@@ -188,22 +188,6 @@ Example:
            --output-metadata {output.metadata:q}
        """
 
-Provide descriptive messages for each rule
-==========================================
-
-Rules support a ``message:`` block which defines a string to print when
-the rule is run. This is very helpful for tracking build progress and in
-general describing what's happening. Note that you can use interpolation
-within the message, so you can surface important parameter values or
-conditional inputs or anything else that might be useful.
-
-Example:
-
-::
-
-   rule traits:
-       message: "Inferring ancestral traits {params.columns!s}"
-
 Always use relative paths
 =========================
 


### PR DESCRIPTION
### Description of proposed changes

This old styleguide contains recommendations that are relevant to the pathogen workflows presently maintained.

### Related issue(s)

Prompted by https://github.com/nextstrain/docs.nextstrain.org/pull/162#pullrequestreview-1546026324.

### Checklist

- [x] Checks pass
- [x] [Preview page](https://nextstrain--164.org.readthedocs.build/en/164/reference/snakemake-style-guide.html) looks good
- [ ] Post-merge: update the [nextstrain-builds.md](https://github.com/blab/styleguide/blob/HEAD/nextstrain-builds.md) document to link to the [new page](https://docs.nextstrain.org/page/reference/snakemake-style-guide.html)
- [ ] Post-merge: update the [README](https://github.com/blab/styleguide/blob/HEAD/README.md) to say this is unused/never used, and archive the repo (so old links still work)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
