### PR TITLE
fetch-via-urls: note colons (:) are not allowed

### DIFF
--- a/src/guides/share/fetch-via-urls.md
+++ b/src/guides/share/fetch-via-urls.md
@@ -29,7 +29,7 @@ Formally, only the [hier-part](https://tools.ietf.org/html/rfc3986#section-3) of
 
 **Suffixes not required** The above examples have assumed that the URL for the dataset JSON ends with `.json`, as is often the case, but this isn't required! For instance, you could have a server which generates a JSON at `https://my-server/makeMeADataset` and access this via `https://nextstrain.org/fetch/my-server/makeMeADataset`.
 
-**Sidecar files** (such as tip-frequency JSONs) are fetched similarly to other sources -- e.g. if the dataset is at `https://A/B.json` then a subsequent request to `https://A/B_tip-frequencies.json` will be made. 
+**Sidecar files** (such as tip-frequency JSONs) are fetched similarly to other sources -- e.g. if the dataset is at `https://A/B.json` then a subsequent request to `https://A/B_tip-frequencies.json` will be made.
 If the fetch URL doesn't end in `.json` then the GET request would be to `https://A/B_tip-frequencies`.
 
 **Authentication** is not currently supported. Please see [Nextstrain Groups](./groups/index) for this!
@@ -38,9 +38,8 @@ If the fetch URL doesn't end in `.json` then the GET request would be to `https:
 
 ### How do I manage the data storage?
 
-That's completely up to you - all that we require for this to work is that it's publicly accessible via a URL over HTTPS. 
+That's completely up to you - all that we require for this to work is that it's publicly accessible via a URL over HTTPS.
 It could be a static asset (e.g. AWS S3) or a server which responds dynamically.
 We recommend the the data is transmitted using compression to improve loading times for the client.
 
 P.S. If you build something interesting here, for instance a server which generates the JSON on-the-fly, we'd love to [hear from you!](mailto:hello@nextstrain.org).
-

--- a/src/guides/share/fetch-via-urls.md
+++ b/src/guides/share/fetch-via-urls.md
@@ -27,6 +27,8 @@ You can see this rendered in Nextstrain at: https://nextstrain.org/fetch/narrati
 **HTTPS only** The [HTTPS](https://developer.mozilla.org/en-US/docs/Glossary/https) protocol is mandated, but "https://" must be left out of the datset URL when it's written as part of the Nextstrain URL.
 Formally, only the [hier-part](https://tools.ietf.org/html/rfc3986#section-3) of the URL is used -- we mandate the scheme to be HTTPS and ignore any queries (or fragments).
 
+**Colons not allowed** The colon (`:`) is reserved as the separator for dual tree displays so they are not allowed in the dataset URL. Using URLs with colons will result in 404 errors.
+
 **Suffixes not required** The above examples have assumed that the URL for the dataset JSON ends with `.json`, as is often the case, but this isn't required! For instance, you could have a server which generates a JSON at `https://my-server/makeMeADataset` and access this via `https://nextstrain.org/fetch/my-server/makeMeADataset`.
 
 **Sidecar files** (such as tip-frequency JSONs) are fetched similarly to other sources -- e.g. if the dataset is at `https://A/B.json` then a subsequent request to `https://A/B_tip-frequencies.json` will be made.


### PR DESCRIPTION
### Description of proposed changes

Since the colon (:) is reserved as the separator for dual tree displays,
the nextstrain.org server splits paths on the colon.¹ This results in a
404 error as the dataset URL is truncated (e.g. when trying to load
Nextclade dataset ref trees)²

We may update the nextstrain.org server to handle colons in dataset URLs
in the future, but better to note this behavior now in case others run
into the same issue.

¹ https://github.com/nextstrain/nextstrain.org/blob/221c67e5dad919edea65787bc11e4cc2227c42ce/src/endpoints/sources.js#L263
² https://github.com/nextstrain/nextstrain.org/issues/702

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
