### PR TITLE
install: Recommend WSL more explicitly among Windows options

### DIFF
--- a/src/install.rst
+++ b/src/install.rst
@@ -52,6 +52,7 @@ Install Nextstrain CLI
          Most of the time, Rosetta 2 will already be enabled.
          If not, the installer will ask you to first enable Rosetta 2 and then retry the installation.
 
+
    .. group-tab:: Windows (PowerShell)
 
       In a PowerShell terminal, run:
@@ -164,19 +165,23 @@ Set up a Nextstrain runtime
 
             .. include:: snippets/nextstrain-setup-conda.rst
 
+
          .. group-tab:: Windows (PowerShell)
 
             .. note::
 
                Due to installation constraints, there is no way to use Nextstrain's Conda runtime on Windows directly. Starting from the beginning, follow steps for **Windows (WSL)** if the Conda runtime is desired, or use the **Docker** runtime instead.
 
+
          .. group-tab:: Windows (WSL)
 
             .. include:: snippets/nextstrain-setup-conda.rst
 
+
          .. group-tab:: Ubuntu Linux
 
             .. include:: snippets/nextstrain-setup-conda.rst
+
 
    .. group-tab:: Ambient (advanced)
 

--- a/src/install.rst
+++ b/src/install.rst
@@ -22,7 +22,7 @@ When completed, you'll be ready to run Nextstrain :term:`workflows <workflow>`.
 Installation steps
 ==================
 
-Steps vary by runtime option (Docker, Conda, ambient) and host interface (macOS, Windows (PowerShell), Windows (WSL), Linux).
+Steps vary by runtime option (Docker, Conda, ambient) and host interface (macOS, Windows (WSL), Windows (PowerShell), Linux).
 For help choosing, refer to our :doc:`/reference/faq`, such as:
 
   * :ref:`what-are-docker-conda-wsl-etc`
@@ -53,18 +53,6 @@ Install Nextstrain CLI
          If not, the installer will ask you to first enable Rosetta 2 and then retry the installation.
 
 
-   .. group-tab:: Windows (PowerShell)
-
-      In a PowerShell terminal, run:
-
-      .. code-block:: powershell
-
-         Invoke-RestMethod https://nextstrain.org/cli/installer/windows | Invoke-Expression
-
-      You can launch a PowerShell terminal by clicking the Start menu, typing ``powershell``, and pressing enter.
-      Make sure to choose the item that is **not** marked "(Adminstrator)".
-
-
    .. group-tab:: Windows (WSL)
 
       `Install Windows Subsystem for Linux (WSL) 2 <https://docs.microsoft.com/en-us/windows/wsl/install>`_.
@@ -77,6 +65,18 @@ Install Nextstrain CLI
          curl -fsSL --proto '=https' https://nextstrain.org/cli/installer/linux | bash
 
       You can launch a WSL terminal by clicking the Start menu, typing ``wsl``, and pressing enter.
+
+
+   .. group-tab:: Windows (PowerShell)
+
+      In a PowerShell terminal, run:
+
+      .. code-block:: powershell
+
+         Invoke-RestMethod https://nextstrain.org/cli/installer/windows | Invoke-Expression
+
+      You can launch a PowerShell terminal by clicking the Start menu, typing ``powershell``, and pressing enter.
+      Make sure to choose the item that is **not** marked "(Adminstrator)".
 
 
    .. group-tab:: Ubuntu Linux
@@ -109,14 +109,6 @@ Set up a Nextstrain runtime
                `Install Docker Desktop for macOS <https://docs.docker.com/desktop/install/mac-install/>`_.
 
 
-            .. group-tab:: Windows (PowerShell)
-
-               `Install Windows Subsystem for Linux (WSL) 2`_.
-               You may have to restart your machine when configuring WSL.
-
-               `Install Docker Desktop for Windows <https://docs.docker.com/desktop/install/windows-install/>`_ with the `WSL 2 backend <https://docs.docker.com/desktop/windows/wsl/>`_.
-
-
             .. group-tab:: Windows (WSL)
 
                `Install Docker Desktop for Windows`_ with the `WSL 2 backend`_.
@@ -127,6 +119,14 @@ Set up a Nextstrain runtime
                   If you forget to do this, ``docker`` won't work in the WSL terminal.
 
                .. include:: snippets/wsl-home-dir.rst
+
+
+            .. group-tab:: Windows (PowerShell)
+
+               `Install Windows Subsystem for Linux (WSL) 2`_.
+               You may have to restart your machine when configuring WSL.
+
+               `Install Docker Desktop for Windows <https://docs.docker.com/desktop/install/windows-install/>`_ with the `WSL 2 backend <https://docs.docker.com/desktop/windows/wsl/>`_.
 
 
             .. group-tab:: Ubuntu Linux
@@ -166,16 +166,16 @@ Set up a Nextstrain runtime
             .. include:: snippets/nextstrain-setup-conda.rst
 
 
+         .. group-tab:: Windows (WSL)
+
+            .. include:: snippets/nextstrain-setup-conda.rst
+
+
          .. group-tab:: Windows (PowerShell)
 
             .. note::
 
                Due to installation constraints, there is no way to use Nextstrain's Conda runtime on Windows directly. Starting from the beginning, follow steps for **Windows (WSL)** if the Conda runtime is desired, or use the **Docker** runtime instead.
-
-
-         .. group-tab:: Windows (WSL)
-
-            .. include:: snippets/nextstrain-setup-conda.rst
 
 
          .. group-tab:: Ubuntu Linux
@@ -202,16 +202,16 @@ Set up a Nextstrain runtime
             .. include:: snippets/ambient-setup.rst
 
 
+         .. group-tab:: Windows (WSL)
+
+            .. include:: snippets/ambient-setup.rst
+
+
          .. group-tab:: Windows (PowerShell)
 
             .. note::
 
                Due to installation constraints, there is no way to use the ambient runtime on Windows directly. Starting from the beginning, follow steps for **Windows (WSL)** if the ambient runtime is desired, or use the **Docker** runtime instead.
-
-
-         .. group-tab:: Windows (WSL)
-
-            .. include:: snippets/ambient-setup.rst
 
 
          .. group-tab:: Ubuntu Linux

--- a/src/install.rst
+++ b/src/install.rst
@@ -22,7 +22,7 @@ When completed, you'll be ready to run Nextstrain :term:`workflows <workflow>`.
 Installation steps
 ==================
 
-Steps vary by runtime option (Docker, Conda, ambient) and operating system (macOS, Windows, WSL on Windows, Linux).
+Steps vary by runtime option (Docker, Conda, ambient) and host interface (macOS, Windows (PowerShell), Windows (WSL), Linux).
 For help choosing, refer to our :doc:`/reference/faq`, such as:
 
   * :ref:`what-are-docker-conda-wsl-etc`
@@ -52,7 +52,7 @@ Install Nextstrain CLI
          Most of the time, Rosetta 2 will already be enabled.
          If not, the installer will ask you to first enable Rosetta 2 and then retry the installation.
 
-   .. group-tab:: Windows
+   .. group-tab:: Windows (PowerShell)
 
       In a PowerShell terminal, run:
 
@@ -64,7 +64,7 @@ Install Nextstrain CLI
       Make sure to choose the item that is **not** marked "(Adminstrator)".
 
 
-   .. group-tab:: WSL on Windows
+   .. group-tab:: Windows (WSL)
 
       `Install Windows Subsystem for Linux (WSL) 2 <https://docs.microsoft.com/en-us/windows/wsl/install>`_.
       You may have to restart your machine when configuring WSL.
@@ -108,7 +108,7 @@ Set up a Nextstrain runtime
                `Install Docker Desktop for macOS <https://docs.docker.com/desktop/install/mac-install/>`_.
 
 
-            .. group-tab:: Windows
+            .. group-tab:: Windows (PowerShell)
 
                `Install Windows Subsystem for Linux (WSL) 2`_.
                You may have to restart your machine when configuring WSL.
@@ -116,7 +116,7 @@ Set up a Nextstrain runtime
                `Install Docker Desktop for Windows <https://docs.docker.com/desktop/install/windows-install/>`_ with the `WSL 2 backend <https://docs.docker.com/desktop/windows/wsl/>`_.
 
 
-            .. group-tab:: WSL on Windows
+            .. group-tab:: Windows (WSL)
 
                `Install Docker Desktop for Windows`_ with the `WSL 2 backend`_.
 
@@ -164,13 +164,13 @@ Set up a Nextstrain runtime
 
             .. include:: snippets/nextstrain-setup-conda.rst
 
-         .. group-tab:: Windows
+         .. group-tab:: Windows (PowerShell)
 
             .. note::
 
-               Due to installation constraints, there is no way to use Nextstrain's Conda runtime on Windows directly. Starting from the beginning, follow steps for **WSL on Windows** if the Conda runtime is desired, or use the **Docker** runtime instead.
+               Due to installation constraints, there is no way to use Nextstrain's Conda runtime on Windows directly. Starting from the beginning, follow steps for **Windows (WSL)** if the Conda runtime is desired, or use the **Docker** runtime instead.
 
-         .. group-tab:: WSL on Windows
+         .. group-tab:: Windows (WSL)
 
             .. include:: snippets/nextstrain-setup-conda.rst
 
@@ -197,14 +197,14 @@ Set up a Nextstrain runtime
             .. include:: snippets/ambient-setup.rst
 
 
-         .. group-tab:: Windows
+         .. group-tab:: Windows (PowerShell)
 
             .. note::
 
-               Due to installation constraints, there is no way to use the ambient runtime on Windows directly. Starting from the beginning, follow steps for **WSL on Windows** if the ambient runtime is desired, or use the **Docker** runtime instead.
+               Due to installation constraints, there is no way to use the ambient runtime on Windows directly. Starting from the beginning, follow steps for **Windows (WSL)** if the ambient runtime is desired, or use the **Docker** runtime instead.
 
 
-         .. group-tab:: WSL on Windows
+         .. group-tab:: Windows (WSL)
 
             .. include:: snippets/ambient-setup.rst
 

--- a/src/reference/faq.rst
+++ b/src/reference/faq.rst
@@ -59,16 +59,19 @@ If you pick one and later realize you want to switch, you can go back and instal
 
 .. _when-to-use-wsl:
 
-When should I use (or not use) WSL on Windows?
-----------------------------------------------
+Should I use PowerShell or WSL on Windows?
+------------------------------------------
 
-All of our Windows installation guides actually require WSL; the difference between them is in the interface you ultimately use for Nextstrain.
-This makes the choice mostly hinge on if you prefer a GNU/Linux `Bash shell <https://www.gnu.org/software/bash/manual/bash.html#What-is-Bash_003f>`__ interface or a Windows `PowerShell <https://docs.microsoft.com/en-us/powershell/scripting/discover-powershell>`__ interface for your command-line work.
-If you don't have a preference (e.g. perhaps you're new to both), we suggest choosing the Bash shell.
+Both of our Windows installation guides require installation of WSL; the difference between them is in the interface you ultimately use for Nextstrain.
+This makes the choice mostly hinge on what interface you prefer for your command-line work:
+
+1. A GNU/Linux `Bash shell <https://www.gnu.org/software/bash/manual/bash.html#What-is-Bash_003f>`__ interface (choose **WSL**)
+2. A Windows `PowerShell <https://docs.microsoft.com/en-us/powershell/scripting/discover-powershell>`__ interface (choose **PowerShell**)
+
+If you don't have a preference (e.g. perhaps you're new to both), we suggest **WSL**.
 Learning Bash will likely be useful in other work, as it is very widely used in bioinformatics and computing at large.
 
-The other deciding factor is if you're unable to install Docker (e.g. for adminstrative or organizational reasons), then you'll need to use the **ambient** runtime with **WSL on Windows**.
-The ambient runtime is not available without WSL.
+The other deciding factor is which runtime(s) you'd like to use. Under **PowerShell**, only the Docker runtime is available. If you're unable to install Docker (e.g. for administrative or organizational reasons), then you'll need to use **WSL** with one of the other runtimes.
 
 
 .. old anchors

--- a/src/reference/faq.rst
+++ b/src/reference/faq.rst
@@ -59,7 +59,7 @@ If you pick one and later realize you want to switch, you can go back and instal
 
 .. _when-to-use-wsl:
 
-Should I use PowerShell or WSL on Windows?
+Should I use WSL or PowerShell on Windows?
 ------------------------------------------
 
 Both of our Windows installation guides require installation of WSL; the difference between them is in the interface you ultimately use for Nextstrain.

--- a/src/snippets/wsl-home-dir.rst
+++ b/src/snippets/wsl-home-dir.rst
@@ -1,4 +1,4 @@
-.. admonition:: For WSL on Windows installs
+.. admonition:: For Windows (WSL) installs
    :class: hint
 
    By default, your Windows home directory will not be directly accessible under your WSL home directory. When run in a WSL prompt, the following command fixes that by creating a symlink to it in your WSL home directory. This allows you to use Windows-based text editors and Linux commands all on the same files.


### PR DESCRIPTION
_Install page: [current](https://docs.nextstrain.org/en/latest/install.html), [preview](https://nextstrain--167.org.readthedocs.build/en/167/install.html)_

### Description of proposed changes

Currently, when choosing between the two Windows options, we recommend the WSL interface to Nextstrain as noted in the FAQ page. However, I don't think the installation page reflects this recommendation well enough. To an inexperienced user, the PowerShell interface (named "Windows") might seem like a better option to choose over "WSL on Windows", which conflicts with the recommendation in FAQ.

This PR renames those options to better reflect the recommendation directly on the install page.

### Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

N/A

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
