### PR TITLE
Snakemake style guide: Add another way of accessing config values

### DIFF
--- a/src/reference/snakemake-style-guide.rst
+++ b/src/reference/snakemake-style-guide.rst
@@ -82,11 +82,15 @@ global variable. 3 ways are supported, but only 2 should be used:
 1. ``config[key]``: Use this when the key is required, or a default is
    specified in a pre-loaded configuration file.
 
-2. ``config.get(key, default)``: Use this when the key is optional.
+2. ``key [not] in config``: Use this when the key is optional and you
+   want to check if a value is specified.
 
-3. ``config.get(key)``: Never use this. All use cases should be covered
-   by (1) and (2). Using this will only mask errors that may be due to a
-   missing required key.
+3. ``config.get(key, default)``: Use this when the key is optional and
+   you want to access its value.
+
+4. ``config.get(key)``: **Never use this**. All use cases should be covered
+   by the options above. Using this will only mask errors that may be
+   due to a missing required key.
 
 Use Snakemake ``params:`` block to map into ``config`` dictionary
 =================================================================


### PR DESCRIPTION
## Description of proposed changes

<!-- What is the goal of this pull request? What does this pull request change? -->

Checking presence of a key in the config should be done with the membership operator. This must be done otherwise false-y values will stay false when membership is checked with `config.get`.

## Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
