### PR TITLE
Specify Read the Docs build OS

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,4 +1,10 @@
 ---
 version: 2
+
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "mambaforge-22.9"
+
 conda:
   environment: environment.yml


### PR DESCRIPTION
## Description of proposed changes

<!-- What is the goal of this pull request? What does this pull request change? -->

Read the Docs will soon require the specification of a build OS in our configuration file [1] and have already started temporary enforcement of this requirement as a warning. This commit follows the example in the RTD docs for conda environments [2], adding a `build` block using the latest supported Ubuntu and mambaforge.

[1] https://blog.readthedocs.com/use-build-os-config/
[2] https://docs.readthedocs.io/en/stable/config-file/v2.html#conda

## Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] [RTD preview build](https://readthedocs.org/projects/nextstrain/builds/21973114/) looks good
- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
