### PR TITLE
Remove Mamba recommendation

### DIFF
--- a/src/reference/faq.rst
+++ b/src/reference/faq.rst
@@ -98,21 +98,23 @@ Why do I get an error when installing to my Conda environment on a Mac computer 
 An example error:
 
 .. code-block:: text
-   :emphasize-lines: 9,10,11,12,13
+   :emphasize-lines: 10,11,12,13,14,15
 
-   (your-environment-name) $ mamba install augur
-
-   Looking for: ['augur']
-
-   bioconda/osx-arm64
+   (your-environment-name) $ conda install augur
 
    …
 
-   Could not solve for environment specs
-   Encountered problems while solving:
-     - nothing provides mafft needed by augur-10.0.0-py_0
+   Platform: osx-arm64
 
-   The environment can't be solved, aborting the operation
+   …
+
+   Collecting package metadata (repodata.json): done
+   Solving environment: failed
+
+   LibMambaUnsatisfiableError: Encountered problems while solving:
+     - nothing provides fasttree needed by augur-10.0.0-py_0
+
+   Could not solve for environment specs
 
 This happens when using an ARM64-based Conda installation on a `computer with Apple silicon <https://support.apple.com/en-us/HT211814>`__, but there are workarounds.
 
@@ -150,7 +152,7 @@ The suitability of the "native" name had long been discussed within the Nextstra
 
 The ambient runtime is native in that sense, but it puts all the software maintenance burden on the user. This means:
 
-1. There is a lengthy setup process which requires installing external software (Conda, Mamba). Additionally, there is no way for us to provide accurate setup steps for users who already have Conda installed, as there are various methods of installing Conda.
+1. There is a lengthy setup process which requires installing external software (Conda). Additionally, there is no way for us to provide accurate setup steps for users who already have Conda installed, as there are various methods of installing Conda.
 2. It is up to you as the creator of the ``nextstrain`` Conda environment to know (a) how to activate it, (b) when to update it, and (c) how to update it.
 
 So really, the ambient runtime is any environment that has been set up with all of the required software available on your local ``PATH``. We chose Conda in the installation instructions since some users may already be familiar with it, and it is simpler than using individual package managers for the various required software (e.g. ``pip``, ``npm``).

--- a/src/snippets/ambient-setup.rst
+++ b/src/snippets/ambient-setup.rst
@@ -6,10 +6,6 @@
 
 2. Install all the necessary software:
 
-   .. note::
-
-      We recommend `Mamba <https://mamba.readthedocs.io>`_ as a drop-in replacement for ``conda`` to have faster installation times.
-
    .. code-block:: bash
 
       conda install --override-channels --strict-channel-priority \


### PR DESCRIPTION
## Description of proposed changes

<!-- What is the goal of this pull request? What does this pull request change? -->

Ambient runtime users are free to choose whatever means of setup. There are many flavors of Conda, and we should only provide a minimal recommendation.

Furthermore, as of conda 23.10.0, libmamba is now the default solver for conda.¹

¹ <https://github.com/conda/conda/releases/tag/23.10.0>

## Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

- Motivated by a recent discovery that [Mamba doesn't work with macOS Sonoma](https://github.com/conda-forge/miniforge/issues/512), but I think a good change even if that wasn't the case.

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
