### PR TITLE
livehtml: Update --ignore pattern to use `**`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ help:
 # fnmatch(), where "*" means something other than a normal glob, for example),
 # but our usage is limited enough for this to work as much as necessary.
 livehtml:
-	sphinx-autobuild -b html $(patsubst %,--ignore "*/%",$(file < .gitignore)) "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	sphinx-autobuild -b html $(patsubst %,--ignore "**%",$(file < .gitignore)) "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 .ONESHELL:
 docker-html:


### PR DESCRIPTION
Resolves https://github.com/nextstrain/docs.nextstrain.org/issues/193

The double asterisk (`**`) glob expression worked for both sphinx-autobuild-2021.03.14 and sphinx-autobuild-2024.2.4. when I tested locally.

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
