### PR TITLE
Update ambient install docs to specify Python version

### DIFF
--- a/src/install.rst
+++ b/src/install.rst
@@ -213,7 +213,7 @@ Set up a Nextstrain runtime
 
       The ambient runtime does not require a particular setup method; it will work as long as the programs you wish to use are available.
 
-      The following describes how to accomplish this using a custom Conda environment as an example. You should be familiar with the `basics of Conda <https://conda.io/projects/conda/en/latest/user-guide/getting-started.html>`__ before proceeding.
+      The following describes how to accomplish this by creating a new custom Conda environment, as an example. You should be familiar with the `basics of Conda <https://conda.io/projects/conda/en/latest/user-guide/getting-started.html>`__ before proceeding. If you want to add Nextstrain to an existing Conda environment, please make sure you're using a compatible Python version (we suggest v3.10.13) and activate that environment instead of creating a new one.
 
       .. tabs::
 

--- a/src/install.rst
+++ b/src/install.rst
@@ -213,7 +213,8 @@ Set up a Nextstrain runtime
 
       The ambient runtime does not require a particular setup method; it will work as long as the programs you wish to use are available.
 
-      The following describes how to accomplish this by creating a new custom Conda environment, as an example. You should be familiar with the `basics of Conda <https://conda.io/projects/conda/en/latest/user-guide/getting-started.html>`__ before proceeding. If you want to add Nextstrain to an existing Conda environment, please make sure you're using a compatible Python version (we suggest v3.10.13) and activate that environment instead of creating a new one.
+      .. Suggest Python 3.10.13 because Augur on Bioconda won't resolve dependencies on Python ≥3.11: <https://github.com/nextstrain/augur/issues/1334>
+      The following describes how to accomplish this by creating a new custom Conda environment, as an example. You should be familiar with the `basics of Conda <https://conda.io/projects/conda/en/latest/user-guide/getting-started.html>`__ before proceeding. If you want to add Nextstrain to an existing Conda environment, please make sure you're using Python ≤3.10 and activate that environment instead of creating a new one.
 
       .. tabs::
 

--- a/src/install.rst
+++ b/src/install.rst
@@ -213,7 +213,8 @@ Set up a Nextstrain runtime
 
       The ambient runtime does not require a particular setup method; it will work as long as the programs you wish to use are available.
 
-      .. Suggest Python 3.10.13 because Augur on Bioconda won't resolve dependencies on Python ≥3.11: <https://github.com/nextstrain/augur/issues/1334>
+      .. Suggest Python ≤3.10 because Augur on Bioconda won't resolve dependencies on Python ≥3.11: <https://github.com/nextstrain/augur/issues/1334>
+
       The following describes how to accomplish this by creating a new custom Conda environment, as an example. You should be familiar with the `basics of Conda <https://conda.io/projects/conda/en/latest/user-guide/getting-started.html>`__ before proceeding. If you want to add Nextstrain to an existing Conda environment, please make sure you're using Python ≤3.10 and activate that environment instead of creating a new one.
 
       .. tabs::

--- a/src/snippets/ambient-setup.rst
+++ b/src/snippets/ambient-setup.rst
@@ -1,21 +1,19 @@
-1. Create a new Conda environment and install Python 3.10.13:
+1. Create a new Conda environment and install all the necessary software:
 
    .. code-block:: bash
 
-      conda create -n <your-environment-name>
-      conda activate <your-environment-name>
-      conda install --override-channels --strict-channel-priority \
-            -c conda-forge --yes python=3.10.13
-
-2. Install all the necessary software:
-
-   .. code-block:: bash
-
-      conda install --override-channels --strict-channel-priority \
+      conda create -n <your-environment-name> \
+            --override-channels --strict-channel-priority \
             -c conda-forge -c bioconda --yes \
             augur auspice nextclade \
             snakemake git epiweeks pangolin pangolearn \
             ncbi-datasets-cli csvtk seqkit tsv-utils
+
+2. Activate the runtime:
+
+   .. code-black:: bash
+
+      conda activate <your-environment-name>
 
 3. Set the runtime:
 

--- a/src/snippets/ambient-setup.rst
+++ b/src/snippets/ambient-setup.rst
@@ -11,7 +11,7 @@
 
 2. Activate the runtime:
 
-   .. code-black:: bash
+   .. code-block:: bash
 
       conda activate <your-environment-name>
 

--- a/src/snippets/ambient-setup.rst
+++ b/src/snippets/ambient-setup.rst
@@ -1,8 +1,11 @@
-1. Activate a Conda environment that you wish to use:
+1. Create a new Conda environment and install Python 3.10.13:
 
    .. code-block:: bash
 
+      conda create -n <your-environment-name>
       conda activate <your-environment-name>
+      conda install --override-channels --strict-channel-priority \
+            -c conda-forge --yes python=3.10.13
 
 2. Install all the necessary software:
 


### PR DESCRIPTION
## Description of proposed changes

Updated the instructions in the ambient section to make it clear that a particular version of Python should be used. I also modified the overall intent of the instructions slightly, so that they direct the user to set up a new Conda environment. The old instructions were oriented more towards adding Nextstrain to an existing Conda enviroment, which (IMO) seems like a less common scenario, and also one more likely to be undertaken by a more experienced user who will be able to adapt these instructions on the fly; doing it this way also side-steps documenting how somebody would need to modify an existing Conda env with an unsupported version of Python.

## Related issue(s)

#201 

## Checklist

- [x] Checks pass
