### PR TITLE
Unpin docutils + sphinx-argparse

### DIFF
--- a/conda.yml
+++ b/conda.yml
@@ -7,12 +7,12 @@ dependencies:
   - pip
   - pip:
     - nextstrain-sphinx-theme>=2022.5
-    - docutils<0.18
+    - docutils
     - recommonmark
     - requests
     - sphinx
     - sphinx-autobuild
     - sphinx-markdown-tables
-    - sphinx-argparse<0.5.0
+    - sphinx-argparse
     - sphinx-tabs
     - sphinx-copybutton


### PR DESCRIPTION
## Description of proposed changes

Follow up to https://github.com/nextstrain/docs.nextstrain.org/pull/215
Mirroring https://github.com/nextstrain/ncov/pull/1127

Unpinning docutils to be able to pull in the latest sphinx-argparse which includes upstream fixes for
https://github.com/nextstrain/docs.nextstrain.org/issues/214


## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
