### PR TITLE
dev: Use conda-forge not the Anaconda default channels

### DIFF
--- a/conda.yml
+++ b/conda.yml
@@ -1,6 +1,6 @@
 name: docs.nextstrain.org
 channels:
-  - defaults
+  - conda-forge
 dependencies:
   - graphviz
   - make


### PR DESCRIPTION
conda-forge is completely open, Anaconda is not.

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
