### PR TITLE
Changes for sphinx-rtd-theme 3.0.0

### DIFF
--- a/src/conf.py
+++ b/src/conf.py
@@ -66,7 +66,7 @@ html_theme = 'nextstrain-sphinx-theme'
 html_static_path = ['static']
 
 html_theme_options = {
-    'display_version': False,
+    'version_selector': False,
     'subproject': False, # For new theme versions
     'logo_only': True,   # For old theme versions
     'collapse_navigation': False,


### PR DESCRIPTION
## Description of proposed changes

In sphinx-rtd-theme version 3.0.0, `display_version` was removed in favor of `version_selector` and `language_selector`.

## Related issue(s)

#216

## Checklist

- [x] `make html` in CI finished without warnings

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
