### PR TITLE
Allow BUILDDIR to be set from environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,11 @@
 #
 
 # You can set these variables from the command line, and also
-# from the environment for the first two.
+# from the environment for the first three.
 SPHINXOPTS    ?=
 SPHINXBUILD   ?= sphinx-build
+BUILDDIR      ?= build
 SOURCEDIR     = src
-BUILDDIR      = build
 
 # Put it first so that "make" without argument is like "make help".
 help:


### PR DESCRIPTION
## Description of proposed changes

No reason not to allow this.

## Related issue(s)

Prompted by https://github.com/nextstrain/.github/pull/110/commits/6332153c6a30416281bad48c0187054546ee6564 while debugging https://github.com/nextstrain/.github/pull/110

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
