### PR TITLE
Allow BUILDDIR to be set from environment

### DIFF
--- a/make.bat
+++ b/make.bat
@@ -7,8 +7,10 @@ REM Command file for Sphinx documentation
 if "%SPHINXBUILD%" == "" (
 	set SPHINXBUILD=sphinx-build
 )
+if "%BUILDDIR%" == "" (
+	set SPHINXBUILD=build
+)
 set SOURCEDIR=src
-set BUILDDIR=build
 
 if "%1" == "" goto help
 


### PR DESCRIPTION
Follow-up to #232 where I forgot the existence of the make.bat file.

## Checklist

- [x] ~Checks pass~ changes are not checked

