### PR TITLE
make.bat: Fix BUILDDIR from environment

### DIFF
--- a/make.bat
+++ b/make.bat
@@ -8,7 +8,7 @@ if "%SPHINXBUILD%" == "" (
 	set SPHINXBUILD=sphinx-build
 )
 if "%BUILDDIR%" == "" (
-	set SPHINXBUILD=build
+	set BUILDDIR=build
 )
 set SOURCEDIR=src
 


### PR DESCRIPTION
Follow-up to #233 where I failed to follow through with copy/paste adjustments.

## Checklist

- [x] ~Checks pass~ changes are not checked