### PR TITLE
reference/ca-certificates: Note that running c_rehash on SSL_CERT_DIR is required

### DIFF
--- a/src/reference/ca-certificates.rst
+++ b/src/reference/ca-certificates.rst
@@ -68,7 +68,8 @@ OpenSSL is the most common library used to provide TLS/SSL support in
 application software.  Its `default locations of trusted CA certificates
 <https://docs.openssl.org/3.0/man3/SSL_CTX_load_verify_locations/>`__ can be
 overridden by setting the ``SSL_CERT_FILE`` and/or ``SSL_CERT_DIR`` environment
-variables.
+variables.  Filenames in the latter must be hashed with OpenSSL's ``c_rehash``
+utility.
 
 Its final trust store is built from certificates in all default locations, so
 to *comprehensively* override the defaults, all locations must be overridden.


### PR DESCRIPTION
This is an important detail that someone generally unfamiliar with these configurations would easily miss and then wonder why their certs weren't being picked up.  The requirement applies not just to applications using OpenSSL, but often also to applications that use other TLS libraries and support SSL_CERT_DIR for compatibility.

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
