### PR TITLE
readthedocs.yml: explicit Sphinx configuration

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -8,3 +8,6 @@ build:
 
 conda:
   environment: conda.yml
+
+sphinx:
+  configuration: src/conf.py


### PR DESCRIPTION
## Description of proposed changes

Prompted by deprecation of RTD's auto-detection of Sphinx configs 
<https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/>

## Related issue(s)

Related to https://github.com/nextstrain/public/issues/15

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
