### PR TITLE
Link to VEME 2022 tutorial repo [#241]

### DIFF
--- a/src/tutorials/creating-a-phylogenetic-workflow.rst
+++ b/src/tutorials/creating-a-phylogenetic-workflow.rst
@@ -4,6 +4,10 @@ Creating a phylogenetic workflow
 
 This tutorial dissects the :term:`single-build workflow<phylogenetic workflow>` used in the previous tutorial. We will first make the build step-by-step. Then we will automate this stepwise process in a :term:`workflow`.
 
+.. tip::
+
+   For an example of these steps using SARS-CoV-2 data, refer to our `VEME 2022 workshop walkthrough <https://github.com/nextstrain/veme-2022>`__.
+
 .. note::
 
    The difference between a :term:`workflow` and :term:`build` isn't obvious with single-build workflows such as this example Zika workflow, but will become more distinct in multi-build workflows such as the SARS-CoV-2 workflow.


### PR DESCRIPTION
## Description of proposed changes

Adds a link to the [VEME 2022 tutorial repo](https://github.com/nextstrain/veme-2022).

## Related issue(s)

Closes #241 

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
