### PR TITLE
Remove paragraph on pipefail with tee

### DIFF
--- a/src/reference/snakemake-style-guide.rst
+++ b/src/reference/snakemake-style-guide.rst
@@ -228,10 +228,6 @@ Example:
            --output-metadata {output.metadata:q}
        """
 
-Before using ``tee``, ensure that your workflow uses `bash's pipefail option <http://redsymbol.net/articles/unofficial-bash-strict-mode/>`_, so successful ``tee`` execution does not mask errors from earlier commands in the pipe.
-Snakemake uses bash's strict mode by default, so the pipefail option should be enabled by default.
-However, some workflows may override the defaults `locally at specific rules <https://snakemake.readthedocs.io/en/stable/project_info/faq.html#my-shell-command-fails-with-exit-code-0-from-within-a-pipe-what-s-wrong>`_ or globally as with `a custom shell prefix <https://github.com/nextstrain/ncov/pull/751>`_.
-
 Run workflows with ``--show-failed-logs``
 =========================================
 


### PR DESCRIPTION
## Description of proposed changes

This was meaningful when the recommendation was

    … | tee {log:q}

It no longer makes sense with changes from #251.

There's still an argument to be made that pipefail should be used with pipes in general, but that is more about shell scripting and does not need to be explicitly mentioned given that Snakemake uses bash's strict mode by default.

## Related issue(s)

Follow-up to https://github.com/nextstrain/docs.nextstrain.org/pull/251#discussion_r2087464717

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
