### PR TITLE
Remove pangolin and pangolearn

### DIFF
--- a/src/snippets/ambient-setup.rst
+++ b/src/snippets/ambient-setup.rst
@@ -6,7 +6,7 @@
             --override-channels --strict-channel-priority \
             -c conda-forge -c bioconda --yes \
             augur auspice nextclade \
-            snakemake git epiweeks pangolin pangolearn \
+            snakemake git epiweeks \
             ncbi-datasets-cli csvtk seqkit tsv-utils
 
 2. Activate the runtime:


### PR DESCRIPTION
## Description of proposed changes

This was previously only used by the ncov workflow, which has [stopped](https://github.com/nextstrain/ncov/commit/b52f0e172654413a1f64ecb9150fcf1176af2a7d) using it. It has also been removed in the [docker](https://github.com/nextstrain/docker-base/commit/50cf352ae9be7eed36c43f91941ffc4b264f69ac) and [conda](https://github.com/nextstrain/conda-base/commit/560e502589bf237eb66b94428f58e8b9528497a4) runtimes.

## Related issue(s)

- https://github.com/nextstrain/ncov/pull/1164
- https://github.com/nextstrain/docker-base/pull/237
- https://github.com/nextstrain/conda-base/pull/14

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
