### PR TITLE
Fix measles links

### DIFF
--- a/src/learn/augur-to-auspice.rst
+++ b/src/learn/augur-to-auspice.rst
@@ -403,7 +403,7 @@ to see the available options here.
 The most comprehensive description of this file is via
 `its schema <https://nextstrain.org/schemas/auspice/config/v2>`__, however to
 introduce this file here's a snippet of the `Auspice config JSON for the
-measles dataset presented above <https://github.com/nextstrain/measles/blob/main/phylogenetic/defaults/auspice_config.json>`__:
+measles dataset presented above <https://github.com/nextstrain/measles/blob/main/phylogenetic/defaults/auspice_config_genome.json>`__:
 
 .. code-block:: json
 
@@ -766,7 +766,7 @@ The **maintainers** (array of dictionaries) is used in the Auspice
 header to identify who created or maintains the dataset.
 
 As an example, here's how the `measles auspice-config uses these
-keys <https://github.com/nextstrain/measles/blob/main/phylogenetic/defaults/auspice_config.json>`__
+keys <https://github.com/nextstrain/measles/blob/main/phylogenetic/defaults/auspice_config_genome.json>`__
 and you can `see here <https://nextstrain.org/measles>`__ how Auspice
 renders these:
 


### PR DESCRIPTION
## Description of proposed changes

Measles auspice config file name was changed in 
<https://github.com/nextstrain/measles/pull/62>

This borked link was flagged in a separate CI workflow for nextstrain/.github <https://github.com/nextstrain/.github/actions/runs/15496400390/job/43634037676>

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
