### PR TITLE
Fix typo in pandas-based query example

### DIFF
--- a/src/guides/bioinformatics/filtering-and-subsampling.rst
+++ b/src/guides/bioinformatics/filtering-and-subsampling.rst
@@ -184,7 +184,7 @@ individual sequence attributes. Examples:
 
             --min-date 2012 \
             --exclude exclude.txt \
-            --query 'region="Asia"' \
+            --query 'region=="Asia"' \
 
        - .. code-block:: yaml
 
@@ -192,16 +192,16 @@ individual sequence attributes. Examples:
               my_sample:
                 min_date: 2012
                 exclude: exclude.txt
-                query: region="Asia"
+                query: region=="Asia"
 
   .. tip::
 
-      The query ``region="Asia"`` is functionally equivalent to the column-based
+      The query ``region=="Asia"`` is functionally equivalent to the column-based
       exclusion ``region!=Asia``. However, the query option allows for more
       complex expressions such as ``(region in {"Asia", "Europe"}) & (coverage
       >= 0.95)``.
 
-      The query ``region="Asia"`` is **not** equivalent to a column-based
+      The query ``region=="Asia"`` is **not** equivalent to a column-based
       force-inclusion ``region=Asia`` since force-inclusive options ignore other
       options (i.e. minimum date and file-based exclusion in the examples
       above).


### PR DESCRIPTION
## Description of proposed changes

Adds a missing equals sign to pandas-style query strings to fix a runtime query syntax error.

## Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [ ] Update changelog

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
