### PR TITLE
Update git repo link for bacterial tutorial

### DIFF
--- a/src/tutorials/creating-a-bacterial-phylogenetic-workflow.rst
+++ b/src/tutorials/creating-a-bacterial-phylogenetic-workflow.rst
@@ -21,7 +21,7 @@ Setup
 
    .. code-block:: bash
 
-      git clone https://github.com/nextstrain/tb
+      git clone --branch north-america-archived https://github.com/nextstrain/tb
       cd tb
 
    .. note::


### PR DESCRIPTION
## Description of proposed changes
We are [creating a new tuberculosis workflow](https://github.com/nextstrain/tb/pull/17) that will replace the original workflow, but the tutorial "Creating a bacterial phylogenetic workflow" is based on the original workflow. We have already moved the original workflow to a branch called `north-america-archived`, and now we need to update the github link in the tutorial to point to that branch.

<!-- What is the goal of this pull request? What does this pull request change? -->

## Related issue(s)
[#15](https://github.com/nextstrain/tb/issues/15)
<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass
- [ ] Update changelog

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
