### PR TITLE
Remove Sphinx version upper bound

### DIFF
--- a/conda.yml
+++ b/conda.yml
@@ -10,9 +10,9 @@ dependencies:
     - docutils
     - recommonmark
     - requests
-    - sphinx>=7.1,<9.0.0
+    - sphinx>=7.1
     - sphinx-autobuild
     - sphinx-markdown-tables
     - sphinx-argparse
-    - sphinx-tabs
+    - sphinx-tabs>=3.5.0
     - sphinx-copybutton


### PR DESCRIPTION
The upper bound was added as a workaround for an [incompatibility](https://github.com/executablebooks/sphinx-tabs/issues/206) between Sphinx ≥9.0.0 and the latest version of sphinx-tabs at the time.

A fix has been released in sphinx-tabs 3.5.0.

Follow-up to https://github.com/nextstrain/docs.nextstrain.org/pull/265

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
