### PR TITLE
Run CI on a schedule

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,11 @@ on:
   pull_request:
   workflow_dispatch:
 
+  # Routinely check that we continue to work in the face of external changes.
+  schedule:
+    # Every Monday at 17:42 UTC / 9:42 Seattle (winter) / 10:42 Seattle (summer)
+    - cron: "42 17 * * 1"
+
 jobs:
   docs:
     name: docs


### PR DESCRIPTION
## Description of proposed changes

Previously, docs CI was only run on sporadic code changes.

The scheduled runs are meant to catch when any existing links break, at a weekly frequency to reduce noise from potential false positives.

## Related issue(s)

- https://github.com/nextstrain/.github/issues/116

## Checklist

- [x] Checks pass
- [x] ~Update changelog~