### PR TITLE
.github/docs: Only run linkcheck on scheduled runs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,3 +20,4 @@ jobs:
       environment-file: conda.yml
       docs-directory: .
       make-target: html
+      run-linkcheck: ${{ github.event_name == 'schedule' }}


### PR DESCRIPTION


## Description of proposed changes

Reduce noise from false positive linkchecks by only running linkcheck for the scheduled workflow runs.

## Related issue(s)

Related to https://github.com/nextstrain/.github/pull/170

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [ ] ~Update changelog~

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
