### PR TITLE
narratives: Fix reference to "authorLinks"

### DIFF
--- a/src/tutorials/narratives-how-to-write.rst
+++ b/src/tutorials/narratives-how-to-write.rst
@@ -180,7 +180,7 @@ This defines a number of key-value pairs which we transform into the slide you s
 The possible content which can be rendered is listed below, in the order they would appear on screen:
 
 #. The main title is taken from the ``title`` key.
-#. The authors are then listed; these can be provided via ``authors`` and ``authorsLinks`` which should either both be strings or both be arrays of the same length. The ``authorsLinks`` is optional but recommended!
+#. The authors are then listed; these can be provided via ``authors`` and ``authorLinks`` which should either both be strings or both be arrays of the same length. The ``authorLinks`` is optional but recommended!
 #. Any translators are then listed, encoded in the same format as the authors but using keys ``translators`` and ``translatorLinks``.
 #. The abstract, defined by ``abstract`` is a string which will be rendered as Markdown [#f1]_.
 #. When the narrative was first created (``date``) and when it was most recently updated (``updated``) is then displayed.


### PR DESCRIPTION

## Description of proposed changes

Corrects reference to "authorLinks" in narrative frontmatter options.

<!-- What is the goal of this pull request? What does this pull request change? -->

## Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass
- [ ] Update changelog

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
