### PR TITLE
Add zstandard to ambient setup

### DIFF
--- a/src/snippets/ambient-setup.rst
+++ b/src/snippets/ambient-setup.rst
@@ -6,7 +6,7 @@
             --override-channels --strict-channel-priority \
             -c conda-forge -c bioconda --yes \
             augur auspice nextclade \
-            snakemake git epiweeks \
+            snakemake git epiweeks zstandard \
             ncbi-datasets-cli csvtk seqkit tsv-utils
 
 2. Activate the runtime:


### PR DESCRIPTION
## Description of proposed changes

Used to be an indirect dependency of Augur, until xopen removed it and we pivoted to the stdlib/backport in
<https://github.com/nextstrain/augur/pull/2009>

Adding here to match the Nextstrain managed runtimes, conda-base¹ and docker-base.²

¹ <https://github.com/nextstrain/conda-base/blob/ede4fa7518fc4e0ccbb6801909f1ecaeef880a7c/src/meta.yaml#L85> 
² <https://github.com/nextstrain/docker-base/pull/286>

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [ ] ~Update changelog~

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
