### PR TITLE
Remove unused extensions

### DIFF
--- a/conda.yml
+++ b/conda.yml
@@ -13,6 +13,5 @@ dependencies:
     - sphinx>=7.1
     - sphinx-autobuild
     - sphinx-markdown-tables
-    - sphinx-argparse
     - sphinx-tabs>=3.5.0
     - sphinx-copybutton

--- a/src/conf.py
+++ b/src/conf.py
@@ -36,8 +36,6 @@ extensions = [
     'recommonmark',
     'sphinx.ext.intersphinx',
     'sphinx_markdown_tables',
-    'sphinxarg.ext',
-    'sphinx.ext.autodoc',
     'sphinx_tabs.tabs',
     'sphinx.ext.graphviz',
     'nextstrain.sphinx.theme',


### PR DESCRIPTION
## Description of proposed changes

The argparse and autodoc extensions were used back when Augur docs were included in this docs project. Those docs have since been moved out to Augur's own subproject, leaving these extensions unused.

The markdown tables extension was also added for Augur docs, but it is still being used in this project.

## Related issue(s)

Fixes failure in [latest scheduled build](https://github.com/nextstrain/docs.nextstrain.org/actions/runs/28813751699/job/85447872177) caused by [sphinx-argparse v0.6.0](https://github.com/sphinx-doc/sphinx-argparse/issues/97)

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass