### PR TITLE
Fix measles links

### DIFF
--- a/src/learn/augur-to-auspice.rst
+++ b/src/learn/augur-to-auspice.rst
@@ -772,15 +772,26 @@ renders these:
 
 .. code-block:: json
 
-  "title": "Tutorial Nextstrain build for Zika virus",
+  "title": "Real-time tracking of measles full genome virus evolution",
   "maintainers": [
-    {"name": "Trevor Bedford", "url": "http://bedford.io/team/trevor-bedford/"}
+    {"name": "Kim Andrews", "url": "https://bedford.io/team/kim-andrews/"},
+    {"name": "the Nextstrain team", "url": "https://nextstrain.org/team"}
   ],
-  "build_url": "https://github.com/nextstrain/zika-tutorial",
-  "panels": [ "tree", "map", "entropy" ],
+  "data_provenance": [
+    {
+      "name": "GenBank",
+      "url": "https://www.ncbi.nlm.nih.gov/genbank/"
+    },
+    {
+      "name": "Pathoplexus",
+      "url": "https://pathoplexus.org"
+    }
+  ],
+  "build_url": "https://github.com/nextstrain/measles",
   "display_defaults": {
-    "map_triplicate": true
-  }
+    "map_triplicate": true,
+    "color_by": "clade"
+  },
 
 --------------
 

--- a/src/learn/augur-to-auspice.rst
+++ b/src/learn/augur-to-auspice.rst
@@ -403,7 +403,7 @@ to see the available options here.
 The most comprehensive description of this file is via
 `its schema <https://nextstrain.org/schemas/auspice/config/v2>`__, however to
 introduce this file here's a snippet of the `Auspice config JSON for the
-measles dataset presented above <https://github.com/nextstrain/measles/blob/main/phylogenetic/defaults/auspice_config_genome.json>`__:
+measles dataset presented above <https://github.com/nextstrain/measles/blob/main/phylogenetic/defaults/auspice_config/genome/global.json>`__:
 
 .. code-block:: json
 
@@ -544,7 +544,7 @@ A colors TSV file may be provided to ``augur export v2`` which is the
 most common way to associate (discrete) values with actual colors. Such
 a file has 3 tab-separated columns: the coloring key, the metadata
 value, and the color hex; no headers are necessary. As an example, `here
-are (some of) the colors TSV <https://github.com/nextstrain/measles/blob/main/phylogenetic/defaults/colors.tsv>`__
+are (some of) the colors TSV <https://github.com/nextstrain/measles/blob/7b0465906a15fd1e89ec0904dbb80af0474676e7/phylogenetic/defaults/colors.tsv>`__
 used in the measles build:
 
 .. code-block:: text
@@ -766,7 +766,7 @@ The **maintainers** (array of dictionaries) is used in the Auspice
 header to identify who created or maintains the dataset.
 
 As an example, here's how the `measles auspice-config uses these
-keys <https://github.com/nextstrain/measles/blob/main/phylogenetic/defaults/auspice_config_genome.json>`__
+keys <https://github.com/nextstrain/measles/blob/main/phylogenetic/defaults/auspice_config/genome/global.json>`__
 and you can `see here <https://nextstrain.org/measles>`__ how Auspice
 renders these:
 


### PR DESCRIPTION
## Description of proposed changes

Fix links flagged by [docs CI](https://github.com/nextstrain/docs.nextstrain.org/actions/runs/30292779892/job/90066302888):

- Replace colors.tsv link with permalink to commit before the file was
removed in <https://github.com/nextstrain/measles/commit/936fa7b38296c6bfe63acf0a653328f58130c415>
- Update Auspice config links to file renamed in
<https://github.com/nextstrain/measles/commit/474ae9d13c90fc4567cf7bc5e5da3288cb38fcad#diff-26a271aa8db8b4d121b2fab3775baccd57379b4aa6ac785e0555a740f06f5345>

Also includes small fix to example Auspice config JSON that I noticed when fixing links. 

## Related issue(s)

Follow up to 
- https://github.com/nextstrain/measles/pull/124
- https://github.com/nextstrain/measles/pull/138

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] ~Update changelog~

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
